### PR TITLE
Rotational and polynomial salcs added, with pretty-printing

### DIFF
--- a/molsym/salcs/axial_vector_functions.py
+++ b/molsym/salcs/axial_vector_functions.py
@@ -1,0 +1,98 @@
+import numpy as np
+from .function_set import FunctionSet
+
+
+class AxialVectorFunctions(FunctionSet):
+    """
+    FunctionSet for axial vectors: Rx, Ry, Rz.
+    Axial vectors transform as:
+        D_axial(g) = det(R_g) R_g
+    where R_g is the ordinary Cartesian representation.
+    """
+
+    def __init__(self, symtext):
+        self.labels = ["Rx", "Ry", "Rz"]
+        fxn_list = [0, 1, 2]
+        super().__init__(symtext, fxn_list)
+
+    def get_fxn_map(self):
+        """
+        Shape:
+            (nsymel, 3, 3)
+
+        Convention:
+            fxn_map[sidx, input_idx, output_idx] = coefficient
+        """
+        fxn_map = np.zeros((len(self.symtext), 3, 3))
+
+        for sidx, symel in enumerate(self.symtext.symels):
+            A = np.array(symel.rrep, dtype=float)
+            A[np.abs(A) < self.symtext.mol.tol] = 0.0
+
+            det = np.linalg.det(A)
+
+            if abs(det - 1.0) < self.symtext.mol.tol:
+                det = 1.0
+            elif abs(det + 1.0) < self.symtext.mol.tol:
+                det = -1.0
+            else:
+                raise ValueError(f"Operation determinant is not ±1: det={det}")
+
+            D = det * A
+
+            # D[row, col] maps input col -> output row.
+            # Store input_idx, output_idx for special_function.
+            fxn_map[sidx, :, :] = D.T
+
+        return fxn_map
+
+    def get_symmetry_equiv_functions(self):
+        """
+        Group axial-vector components by actual symmetry mixing.
+        """
+        nfxn = 3
+        done = set()
+        equiv_sets = []
+
+        for start in range(nfxn):
+            if start in done:
+                continue
+
+            orbit = set([start])
+            frontier = [start]
+
+            while frontier:
+                coord = frontier.pop()
+
+                for sidx in range(len(self.symtext)):
+                    coeffs = self.fxn_map[sidx, coord, :]
+
+                    mapped = [i for i, coeff in enumerate(coeffs) if abs(coeff) > self.symtext.mol.tol]
+
+                    for idx in mapped:
+                        if idx not in orbit:
+                            orbit.add(idx)
+                            frontier.append(idx)
+
+            equiv_set = sorted(orbit)
+            equiv_sets.append(equiv_set)
+            done.update(equiv_set)
+
+        return equiv_sets
+
+    def special_function(self, salc, coord, sidx, irrmat):
+        """
+        Project one axial-vector component under symmetry operation sidx.
+        """
+        coeffs = self.fxn_map[sidx, coord, :]
+
+        for out_idx, coeff in enumerate(coeffs):
+            if abs(coeff) < self.symtext.mol.tol:
+                continue
+
+            if self.symtext.complex:
+                salc[:, :, out_idx] += np.conj(irrmat[sidx, :, :]) * coeff
+            else:
+                salc[:, :, out_idx] += irrmat[sidx, :, :] * coeff
+
+        return salc

--- a/molsym/salcs/axial_vector_functions.py
+++ b/molsym/salcs/axial_vector_functions.py
@@ -15,6 +15,16 @@ class AxialVectorFunctions(FunctionSet):
         fxn_list = [0, 1, 2]
         super().__init__(symtext, fxn_list)
 
+    def print_salcs(self, salcs):
+        from molsym.salcs.salc_tools import format_salcs
+        #return str(format_axial_vector_salcs(salcs))
+        return str(format_salcs(salcs))
+   
+    def salc_to_string(self, salc):
+        from molsym.salcs.salc_tools import axial_vector_salc_to_string
+        return axial_vector_salc_to_string(salc, self)
+
+
     def get_fxn_map(self):
         """
         Shape:

--- a/molsym/salcs/axial_vector_functions.py
+++ b/molsym/salcs/axial_vector_functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 from .function_set import FunctionSet
+from .salc_tools import axial_matrix, axial_vector_salc_to_string, format_salcs
 
 
 class AxialVectorFunctions(FunctionSet):
@@ -16,13 +17,10 @@ class AxialVectorFunctions(FunctionSet):
         super().__init__(symtext, fxn_list)
 
     def print_salcs(self, salcs):
-        from molsym.salcs.salc_tools import format_salcs
         return str(format_salcs(salcs))
-   
-    def salc_to_string(self, salc):
-        from molsym.salcs.salc_tools import axial_vector_salc_to_string
-        return axial_vector_salc_to_string(salc, self)
 
+    def salc_to_string(self, salc):
+        return axial_vector_salc_to_string(salc, self)
 
     def get_fxn_map(self):
         """
@@ -32,8 +30,6 @@ class AxialVectorFunctions(FunctionSet):
         Convention:
             fxn_map[sidx, input_idx, output_idx] = coefficient
         """
-        from molsym.salcs.salc_tools import axial_matrix
-
         fxn_map = np.zeros((len(self.symtext), 3, 3))
 
         for sidx, symel in enumerate(self.symtext.symels):

--- a/molsym/salcs/axial_vector_functions.py
+++ b/molsym/salcs/axial_vector_functions.py
@@ -17,7 +17,6 @@ class AxialVectorFunctions(FunctionSet):
 
     def print_salcs(self, salcs):
         from molsym.salcs.salc_tools import format_salcs
-        #return str(format_axial_vector_salcs(salcs))
         return str(format_salcs(salcs))
    
     def salc_to_string(self, salc):

--- a/molsym/salcs/axial_vector_functions.py
+++ b/molsym/salcs/axial_vector_functions.py
@@ -32,22 +32,13 @@ class AxialVectorFunctions(FunctionSet):
         Convention:
             fxn_map[sidx, input_idx, output_idx] = coefficient
         """
+        from molsym.salcs.salc_tools import axial_matrix
+
         fxn_map = np.zeros((len(self.symtext), 3, 3))
 
         for sidx, symel in enumerate(self.symtext.symels):
             A = np.array(symel.rrep, dtype=float)
-            A[np.abs(A) < self.symtext.mol.tol] = 0.0
-
-            det = np.linalg.det(A)
-
-            if abs(det - 1.0) < self.symtext.mol.tol:
-                det = 1.0
-            elif abs(det + 1.0) < self.symtext.mol.tol:
-                det = -1.0
-            else:
-                raise ValueError(f"Operation determinant is not ±1: det={det}")
-
-            D = det * A
+            D = axial_matrix(A, self.symtext.mol.tol)
 
             # D[row, col] maps input col -> output row.
             # Store input_idx, output_idx for special_function.

--- a/molsym/salcs/internal_coordinates.py
+++ b/molsym/salcs/internal_coordinates.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import numpy as np
 from molsym.salcs.function_set import FunctionSet
+from molsym.salcs.salc_tools import format_salcs, internal_coordinate_salc_to_string
 
 class IC():
     def __init__(self, atom_list):
@@ -111,11 +112,9 @@ class InternalCoordinates(FunctionSet):
 
         
     def print_salcs(self, salcs):
-        from molsym.salcs.salc_tools import format_salcs
         return str(format_salcs(salcs))
 
     def salc_to_string(self, salc):
-        from molsym.salcs.salc_tools import internal_coordinate_salc_to_string
         return internal_coordinate_salc_to_string(salc, self)
 
     def find_equiv_ic(self, ic):

--- a/molsym/salcs/internal_coordinates.py
+++ b/molsym/salcs/internal_coordinates.py
@@ -12,6 +12,7 @@ class IC():
         self.exchange_atoms = None
         self.perm_symmetry = list # Does nothing
 
+
     def is_equiv(self, ic):
         if isinstance(ic, self.__class__):
             if self.atom_list == ic.atom_list:
@@ -104,8 +105,18 @@ def user_to_IC(ic_list):
 
 class InternalCoordinates(FunctionSet):
     def __init__(self, symtext, fxn_list):
+        self.labels = [ic[1] for ic in fxn_list]
         self.ic_list = [user_to_IC(i) for i in fxn_list]
         super().__init__(symtext, fxn_list)
+
+        
+    def print_salcs(self, salcs):
+        from molsym.salcs.salc_tools import format_salcs
+        return str(format_salcs(salcs))
+
+    def salc_to_string(self, salc):
+        from molsym.salcs.salc_tools import internal_coordinate_salc_to_string
+        return internal_coordinate_salc_to_string(salc, self)
 
     def find_equiv_ic(self, ic):
         for idx, ic_i in enumerate(self.ic_list):

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -1,0 +1,342 @@
+import numpy as np
+from math import comb
+from .function_set import FunctionSet
+from molsym.molecule import *
+
+
+class PolynomialFunctions(FunctionSet):
+    """
+    FunctionSet for homogeneous Cartesian polynomial monomials.
+    Basis functions are exponent tuples:
+        (a, b, c) -> x^a y^b z^c
+    """
+
+    def __init__(self, symtext, degree=2):
+        self.degree = degree
+        self.exponents = monomial_exponents(degree)
+        fxn_list = list(range(len(self.exponents)))
+        super().__init__(symtext, fxn_list)
+
+    def get_fxn_map(self):
+        """
+        Build representation matrices for each symmetry operation.
+
+        Shape:
+            (nsymel, nfxn, nfxn)
+
+        Convention:
+            fxn_map[sidx, input_idx, output_idx] = coefficient
+        """
+        nfxn = len(self.exponents)
+        fxn_map = np.zeros((len(self.symtext), nfxn, nfxn))
+
+        for sidx, symel in enumerate(self.symtext.symels):
+            A = np.array(symel.rrep, dtype=float)
+            A[np.abs(A) < global_tol] = 0.0
+
+            D = polynomial_representation_matrix(A,self.exponents,tol=global_tol)
+
+            # D[row, col] maps input col -> output row.
+            # Store as input_idx, output_idx for special_function convenience.
+            fxn_map[sidx, :, :] = D.T
+
+        return fxn_map
+    def orbit_span_indices(self, seed, component):
+        """
+        Determine which monomials inside a connected polynomial-mixing
+        component are reached by the group orbit of one seed monomial.
+
+        A monomial is considered reached if some symmetry operation maps
+        the seed monomial onto it with nonzero coefficient.
+
+        :type seed: int
+        :type component: list[int]
+        :return: Set of reachable monomial indices
+        :rtype: set[int]
+        """
+        reached = set()
+    
+        for sidx in range(len(self.symtext)):
+            coeffs = self.fxn_map[sidx, seed, :]
+    
+            for idx, coeff in enumerate(coeffs):
+                if idx in component and abs(coeff) > global_tol:
+                    reached.add(idx)
+    
+        return reached
+    
+    def get_symmetry_equiv_functions(self):
+        """
+        Construct symmetry-equivalent seed sets for polynomial projection.
+
+        First identifies invariant mixing components under the polynomial
+        representation. Then selects enough seed monomials so that the
+        union of their group orbits spans the entire component.
+
+        This avoids missing irreducible subspaces in non-cyclic polynomial
+        blocks, such as the cubic planar block in C3v:
+            {x^3, x^2y, xy^2, y^3}
+
+        where x^3 alone cannot generate the A2 component.
+
+        :return: List of symmetry-equivalent seed sets
+        :rtype: list[list[int]]
+        """
+        nfxn = len(self.exponents)
+        done = set()
+        seed_sets = []
+    
+        for start in range(nfxn):
+            if start in done:
+                continue
+    
+            # ------------------------------------------------------------
+            # 1. Find the invariant mixing component.
+            # ------------------------------------------------------------
+            component = set([start])
+            frontier = [start]
+    
+            while frontier:
+                coord = frontier.pop()
+    
+                for sidx in range(len(self.symtext)):
+                    coeffs = self.fxn_map[sidx, coord, :]
+    
+                    mapped = [
+                        i for i, coeff in enumerate(coeffs)
+                        if abs(coeff) > global_tol
+                    ]
+    
+                    for idx in mapped:
+                        if idx not in component:
+                            component.add(idx)
+                            frontier.append(idx)
+    
+            component = sorted(component)
+            done.update(component)
+    
+            # ------------------------------------------------------------
+            # 2. Choose cyclic generator seeds inside this component.
+            #    A seed is kept if its group orbit increases the rank/span.
+            # ------------------------------------------------------------
+            component_pos = {
+                idx: pos
+                for pos, idx in enumerate(component)
+            }
+    
+            current_basis = np.zeros((len(component), 0))
+    
+            for seed in component:
+                orbit_vectors = []
+    
+                for sidx in range(len(self.symtext)):
+                    coeffs = self.fxn_map[sidx, seed, :]
+    
+                    v = np.zeros(len(component))
+    
+                    for idx in component:
+                        v[component_pos[idx]] = coeffs[idx]
+    
+                    orbit_vectors.append(v)
+    
+                orbit_matrix = np.column_stack(orbit_vectors)
+    
+                if current_basis.shape[1] == 0:
+                    old_rank = 0
+                    trial = orbit_matrix
+                else:
+                    old_rank = np.linalg.matrix_rank(current_basis,tol=global_tol)
+                    trial = np.column_stack((current_basis, orbit_matrix))
+    
+                new_rank = np.linalg.matrix_rank(trial,tol=global_tol)
+    
+                if new_rank > old_rank:
+                    # ProjectionOp only uses min(se_fxn_set), so return
+                    # this seed as its own set.
+                    seed_sets.append([seed])
+                    current_basis = trial
+    
+                if new_rank == len(component):
+                    break
+    
+        return seed_sets
+
+    def special_function(self, salc, coord, sidx, irrmat):
+        """
+        Apply one symmetry operation to a polynomial monomial basis function
+        during projection-operator construction.
+
+        The transformed monomial is expanded in the polynomial basis and
+        accumulated into the SALC tensor with the appropriate irrep matrix
+        weighting.
+
+        :type salc: np.ndarray
+        :type coord: int
+        :type sidx: int
+        :type irrmat: np.ndarray
+        :return: Updated SALC tensor
+        :rtype: np.ndarray
+        """
+        coeffs = self.fxn_map[sidx, coord, :]
+
+        for out_idx, coeff in enumerate(coeffs):
+            if abs(coeff) < global_tol:
+                continue
+
+            if self.symtext.complex:
+                salc[:, :, out_idx] += np.conj(irrmat[sidx, :, :]) * coeff
+            else:
+                salc[:, :, out_idx] += irrmat[sidx, :, :] * coeff
+
+        return salc
+
+
+def monomial_exponents(degree):
+    """
+    Generate exponent tuples for homogeneous Cartesian monomials of
+    fixed total degree.
+
+    Example for degree 2:
+        [(2,0,0), (1,1,0), (1,0,1), ...]
+
+    corresponding to:
+        x^2, xy, xz, ...
+
+    :type degree: int
+    :return: List of exponent tuples (a,b,c)
+    :rtype: list[tuple[int,int,int]]
+    """
+    basis = []
+
+    for a in range(degree, -1, -1):
+        for b in range(degree - a, -1, -1):
+            c = degree - a - b
+            basis.append((a, b, c))
+
+    return basis
+
+
+def multinomial_terms_for_power(linear_coeffs, power, tol=global_tol):
+    """
+    Expand a linear polynomial raised to an integer power using the
+    multinomial theorem.
+
+    Computes:
+        (ax*x + ay*y + az*z)^power
+
+    and returns the resulting polynomial as a dictionary mapping
+    exponent tuples to coefficients.
+
+    :type linear_coeffs: np.ndarray
+    :type power: int
+    :type tol: float
+    :return: Polynomial dictionary mapping exponent tuples to coefficients
+    :rtype: dict[tuple[int,int,int], float]
+    """
+    terms = {}
+    ax, ay, az = linear_coeffs
+
+    for i in range(power + 1):
+        for j in range(power - i + 1):
+            k = power - i - j
+
+            coeff = (
+                comb(power, i)
+                * comb(power - i, j)
+                * (ax ** i)
+                * (ay ** j)
+                * (az ** k)
+            )
+
+            if abs(coeff) > tol:
+                terms[(i, j, k)] = coeff
+
+    return terms
+
+
+def multiply_poly_dicts(p1, p2, tol=global_tol):
+    """
+    Multiply two multivariate polynomial dictionaries.
+
+    Polynomial dictionaries map exponent tuples to coefficients:
+        (a,b,c) -> coeff
+
+    Terms with coefficients below tolerance are discarded.
+
+    :type p1: dict
+    :type p2: dict
+    :type tol: float
+    :return: Product polynomial dictionary
+    :rtype: dict
+    """
+    out = {}
+
+    for e1, c1 in p1.items():
+        for e2, c2 in p2.items():
+            exp = tuple(e1[i] + e2[i] for i in range(3))
+            out[exp] = out.get(exp, 0.0) + c1 * c2
+
+    return {
+        exp: coeff
+        for exp, coeff in out.items()
+        if abs(coeff) > tol
+    }
+
+
+def transform_monomial(exp, A, tol=global_tol):
+    """
+    Transform one Cartesian monomial under a coordinate transformation.
+
+    The coordinate transformation is defined by:
+        x' = A[0,0]x + A[0,1]y + A[0,2]z
+        y' = A[1,0]x + A[1,1]y + A[1,2]z
+        z' = A[2,0]x + A[2,1]y + A[2,2]z
+
+    The transformed monomial is expanded into the Cartesian monomial basis.
+
+    :type exp: tuple[int,int,int]
+    :type A: np.ndarray
+    :type tol: float
+    :return: Polynomial dictionary representation of transformed monomial
+    :rtype: dict[tuple[int,int,int], float]
+    """
+    a, b, c = exp
+
+    px = multinomial_terms_for_power(A[0, :], a, tol)
+    py = multinomial_terms_for_power(A[1, :], b, tol)
+    pz = multinomial_terms_for_power(A[2, :], c, tol)
+
+    poly = {(0, 0, 0): 1.0}
+    poly = multiply_poly_dicts(poly, px, tol)
+    poly = multiply_poly_dicts(poly, py, tol)
+    poly = multiply_poly_dicts(poly, pz, tol)
+
+    return poly
+
+
+def polynomial_representation_matrix(A, basis, tol=global_tol):
+    """
+    Construct the polynomial representation matrix D(g) for a symmetry
+    operation acting on a Cartesian monomial basis.
+
+    Each column corresponds to one input monomial basis function, and
+    each row gives the coefficients of the transformed polynomial.
+
+    :type A: np.ndarray
+    :type basis: list[tuple[int,int,int]]
+    :type tol: float
+    :return: Polynomial representation matrix
+    :rtype: np.ndarray
+    """
+    index = {exp: i for i, exp in enumerate(basis)}
+    D = np.zeros((len(basis), len(basis)))
+
+    for col, exp in enumerate(basis):
+        transformed = transform_monomial(exp, A, tol)
+
+        for out_exp, coeff in transformed.items():
+            row = index[out_exp]
+            D[row, col] += coeff
+
+    D[np.abs(D) < tol] = 0.0
+    return D

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -19,7 +19,6 @@ class PolynomialFunctions(FunctionSet):
 
     def print_salcs(self, salcs):
         from molsym.salcs.salc_tools import format_salcs
-        #return str(format_polynomial_salcs(salcs))
         return str(format_salcs(salcs))
 
     def salc_to_string(self, salc):

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -90,9 +90,6 @@ class PolynomialFunctions(FunctionSet):
             if start in done:
                 continue
     
-            # ------------------------------------------------------------
-            # 1. Find the invariant mixing component.
-            # ------------------------------------------------------------
             component = set([start])
             frontier = [start]
     
@@ -102,10 +99,7 @@ class PolynomialFunctions(FunctionSet):
                 for sidx in range(len(self.symtext)):
                     coeffs = self.fxn_map[sidx, coord, :]
     
-                    mapped = [
-                        i for i, coeff in enumerate(coeffs)
-                        if abs(coeff) > global_tol
-                    ]
+                    mapped = [i for i, coeff in enumerate(coeffs) if abs(coeff) > global_tol]
     
                     for idx in mapped:
                         if idx not in component:
@@ -115,14 +109,7 @@ class PolynomialFunctions(FunctionSet):
             component = sorted(component)
             done.update(component)
     
-            # ------------------------------------------------------------
-            # 2. Choose cyclic generator seeds inside this component.
-            #    A seed is kept if its group orbit increases the rank/span.
-            # ------------------------------------------------------------
-            component_pos = {
-                idx: pos
-                for pos, idx in enumerate(component)
-            }
+            component_pos = {idx: pos for pos, idx in enumerate(component)}
     
             current_basis = np.zeros((len(component), 0))
     

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -17,6 +17,15 @@ class PolynomialFunctions(FunctionSet):
         fxn_list = list(range(len(self.exponents)))
         super().__init__(symtext, fxn_list)
 
+    def print_salcs(self, salcs):
+        from molsym.salcs.salc_tools import format_salcs
+        #return str(format_polynomial_salcs(salcs))
+        return str(format_salcs(salcs))
+
+    def salc_to_string(self, salc):
+        from molsym.salcs.salc_tools import polynomial_salc_to_string
+        return polynomial_salc_to_string(salc, self)
+
     def get_fxn_map(self):
         """
         Build representation matrices for each symmetry operation.

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -1,7 +1,7 @@
 import numpy as np
 from math import comb
 from .function_set import FunctionSet
-from molsym.molecule import *
+from molsym.molecule import global_tol
 
 
 class PolynomialFunctions(FunctionSet):

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -27,7 +27,7 @@ class PolynomialFunctions(FunctionSet):
 
     def get_fxn_map(self):
         """
-        Build representation matrices for each symmetry operation.
+        Build polynomial transformatation matrices for each symmetry operation.
 
         Shape:
             (nsymel, nfxn, nfxn)
@@ -42,36 +42,13 @@ class PolynomialFunctions(FunctionSet):
             A = np.array(symel.rrep, dtype=float)
             A[np.abs(A) < global_tol] = 0.0
 
-            D = polynomial_representation_matrix(A,self.exponents,tol=global_tol)
+            T = polynomial_transformation_matrix(A,self.exponents,tol=global_tol)
 
-            # D[row, col] maps input col -> output row.
+            # T[row, col] maps input col -> output row.
             # Store as input_idx, output_idx for special_function convenience.
-            fxn_map[sidx, :, :] = D.T
+            fxn_map[sidx, :, :] = T.T
 
         return fxn_map
-    def orbit_span_indices(self, seed, component):
-        """
-        Determine which monomials inside a connected polynomial-mixing
-        component are reached by the group orbit of one seed monomial.
-
-        A monomial is considered reached if some symmetry operation maps
-        the seed monomial onto it with nonzero coefficient.
-
-        :type seed: int
-        :type component: list[int]
-        :return: Set of reachable monomial indices
-        :rtype: set[int]
-        """
-        reached = set()
-    
-        for sidx in range(len(self.symtext)):
-            coeffs = self.fxn_map[sidx, seed, :]
-    
-            for idx, coeff in enumerate(coeffs):
-                if idx in component and abs(coeff) > global_tol:
-                    reached.add(idx)
-    
-        return reached
     
     def get_symmetry_equiv_functions(self):
         """
@@ -184,7 +161,6 @@ class PolynomialFunctions(FunctionSet):
                 salc[:, :, out_idx] += irrmat[sidx, :, :] * coeff
 
         return salc
-
 
 def monomial_exponents(degree):
     """
@@ -309,29 +285,41 @@ def transform_monomial(exp, A, tol=global_tol):
     return poly
 
 
-def polynomial_representation_matrix(A, basis, tol=global_tol):
+def polynomial_transformation_matrix(A, basis, tol=global_tol):
     """
-    Construct the polynomial representation matrix D(g) for a symmetry
-    operation acting on a Cartesian monomial basis.
+    Construct the matrix representation of a linear coordinate transformation
+    on a homogeneous Cartesian polynomial basis.
 
-    Each column corresponds to one input monomial basis function, and
-    each row gives the coefficients of the transformed polynomial.
+    Given a 3×3 matrix ``A`` acting on Cartesian coordinates, this function
+    computes the corresponding transformation matrix acting on the polynomial
+    basis specified by ``basis``. Each column corresponds to one input basis
+    function, and each row contains the coefficients of its transformed
+    polynomial expressed in the same basis.
 
-    :type A: np.ndarray
-    :type basis: list[tuple[int,int,int]]
-    :type tol: float
-    :return: Polynomial representation matrix
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    A : np.ndarray
+        3×3 linear transformation acting on Cartesian coordinates.
+    basis : list[tuple[int, int, int]]
+        Homogeneous polynomial basis represented by exponent tuples
+        ``(a, b, c)``, corresponding to monomials ``x^a y^b z^c``.
+    tol : float
+        Values with magnitude below this tolerance are set to zero.
+
+    Returns
+    -------
+    np.ndarray
+        Transformation matrix acting on the polynomial basis.
     """
     index = {exp: i for i, exp in enumerate(basis)}
-    D = np.zeros((len(basis), len(basis)))
+    T = np.zeros((len(basis), len(basis)))
 
     for col, exp in enumerate(basis):
         transformed = transform_monomial(exp, A, tol)
 
         for out_exp, coeff in transformed.items():
             row = index[out_exp]
-            D[row, col] += coeff
+            T[row, col] += coeff
 
-    D[np.abs(D) < tol] = 0.0
-    return D
+    T[np.abs(T) < tol] = 0.0
+    return T

--- a/molsym/salcs/polynomial_functions.py
+++ b/molsym/salcs/polynomial_functions.py
@@ -1,6 +1,7 @@
 import numpy as np
 from math import comb
 from .function_set import FunctionSet
+from .salc_tools import format_salcs, polynomial_salc_to_string
 from molsym.molecule import global_tol
 
 
@@ -18,11 +19,9 @@ class PolynomialFunctions(FunctionSet):
         super().__init__(symtext, fxn_list)
 
     def print_salcs(self, salcs):
-        from molsym.salcs.salc_tools import format_salcs
         return str(format_salcs(salcs))
 
     def salc_to_string(self, salc):
-        from molsym.salcs.salc_tools import polynomial_salc_to_string
         return polynomial_salc_to_string(salc, self)
 
     def get_fxn_map(self):
@@ -40,9 +39,8 @@ class PolynomialFunctions(FunctionSet):
 
         for sidx, symel in enumerate(self.symtext.symels):
             A = np.array(symel.rrep, dtype=float)
-            A[np.abs(A) < global_tol] = 0.0
 
-            T = polynomial_transformation_matrix(A,self.exponents,tol=global_tol)
+            T = polynomial_transformation_matrix(A, self.exponents)
 
             # T[row, col] maps input col -> output row.
             # Store as input_idx, output_idx for special_function convenience.
@@ -187,7 +185,7 @@ def monomial_exponents(degree):
     return basis
 
 
-def multinomial_terms_for_power(linear_coeffs, power, tol=global_tol):
+def multinomial_terms_for_power(linear_coeffs, power):
     """
     Expand a linear polynomial raised to an integer power using the
     multinomial theorem.
@@ -200,7 +198,6 @@ def multinomial_terms_for_power(linear_coeffs, power, tol=global_tol):
 
     :type linear_coeffs: np.ndarray
     :type power: int
-    :type tol: float
     :return: Polynomial dictionary mapping exponent tuples to coefficients
     :rtype: dict[tuple[int,int,int], float]
     """
@@ -211,7 +208,7 @@ def multinomial_terms_for_power(linear_coeffs, power, tol=global_tol):
         for j in range(power - i + 1):
             k = power - i - j
 
-            coeff = (
+            terms[(i, j, k)] = (
                 comb(power, i)
                 * comb(power - i, j)
                 * (ax ** i)
@@ -219,24 +216,18 @@ def multinomial_terms_for_power(linear_coeffs, power, tol=global_tol):
                 * (az ** k)
             )
 
-            if abs(coeff) > tol:
-                terms[(i, j, k)] = coeff
-
     return terms
 
 
-def multiply_poly_dicts(p1, p2, tol=global_tol):
+def multiply_poly_dicts(p1, p2):
     """
     Multiply two multivariate polynomial dictionaries.
 
     Polynomial dictionaries map exponent tuples to coefficients:
         (a,b,c) -> coeff
 
-    Terms with coefficients below tolerance are discarded.
-
     :type p1: dict
     :type p2: dict
-    :type tol: float
     :return: Product polynomial dictionary
     :rtype: dict
     """
@@ -247,14 +238,10 @@ def multiply_poly_dicts(p1, p2, tol=global_tol):
             exp = tuple(e1[i] + e2[i] for i in range(3))
             out[exp] = out.get(exp, 0.0) + c1 * c2
 
-    return {
-        exp: coeff
-        for exp, coeff in out.items()
-        if abs(coeff) > tol
-    }
+    return out
 
 
-def transform_monomial(exp, A, tol=global_tol):
+def transform_monomial(exp, A):
     """
     Transform one Cartesian monomial under a coordinate transformation.
 
@@ -267,25 +254,24 @@ def transform_monomial(exp, A, tol=global_tol):
 
     :type exp: tuple[int,int,int]
     :type A: np.ndarray
-    :type tol: float
     :return: Polynomial dictionary representation of transformed monomial
     :rtype: dict[tuple[int,int,int], float]
     """
     a, b, c = exp
 
-    px = multinomial_terms_for_power(A[0, :], a, tol)
-    py = multinomial_terms_for_power(A[1, :], b, tol)
-    pz = multinomial_terms_for_power(A[2, :], c, tol)
+    px = multinomial_terms_for_power(A[0, :], a)
+    py = multinomial_terms_for_power(A[1, :], b)
+    pz = multinomial_terms_for_power(A[2, :], c)
 
     poly = {(0, 0, 0): 1.0}
-    poly = multiply_poly_dicts(poly, px, tol)
-    poly = multiply_poly_dicts(poly, py, tol)
-    poly = multiply_poly_dicts(poly, pz, tol)
+    poly = multiply_poly_dicts(poly, px)
+    poly = multiply_poly_dicts(poly, py)
+    poly = multiply_poly_dicts(poly, pz)
 
     return poly
 
 
-def polynomial_transformation_matrix(A, basis, tol=global_tol):
+def polynomial_transformation_matrix(A, basis):
     """
     Construct the matrix representation of a linear coordinate transformation
     on a homogeneous Cartesian polynomial basis.
@@ -303,8 +289,6 @@ def polynomial_transformation_matrix(A, basis, tol=global_tol):
     basis : list[tuple[int, int, int]]
         Homogeneous polynomial basis represented by exponent tuples
         ``(a, b, c)``, corresponding to monomials ``x^a y^b z^c``.
-    tol : float
-        Values with magnitude below this tolerance are set to zero.
 
     Returns
     -------
@@ -315,11 +299,10 @@ def polynomial_transformation_matrix(A, basis, tol=global_tol):
     T = np.zeros((len(basis), len(basis)))
 
     for col, exp in enumerate(basis):
-        transformed = transform_monomial(exp, A, tol)
+        transformed = transform_monomial(exp, A)
 
         for out_exp, coeff in transformed.items():
             row = index[out_exp]
             T[row, col] += coeff
 
-    T[np.abs(T) < tol] = 0.0
     return T

--- a/molsym/salcs/salc.py
+++ b/molsym/salcs/salc.py
@@ -40,11 +40,18 @@ class SALCs():
     def __len__(self):
         return len(self.salcs)
 
+    
     def __str__(self) -> str:
+        style = getattr(self.fxn_set, "salc_print_style", "default")
+
+        if style == "pretty" and hasattr(self.fxn_set, "print_salcs"):
+            return self.fxn_set.print_salcs(self)
+
         out = ""
-        for i in self.salcs:
-            out += str(i)
+        for salc in self.salcs:
+            out += str(salc)
         return out
+ 
     
     def __repr__(self) -> str:
         return self.__str__()

--- a/molsym/salcs/salc_tools.py
+++ b/molsym/salcs/salc_tools.py
@@ -1,5 +1,4 @@
 import numpy as np
-from math import comb
 import re
 from molsym.salcs.projection_op import ProjectionOp
 from molsym.salcs.axial_vector_functions import AxialVectorFunctions
@@ -144,7 +143,6 @@ def analyze_rotations(symtext, print_pretty=True):
     salcs = ProjectionOp(symtext,fxn_set,project_Eckart=False)
 
     return salcs
-    return format_reduction(coeffs, symtext)
 
 def axial_vector_salc_to_string(salc, fxn_set, tol=global_tol):
     terms = []

--- a/molsym/salcs/salc_tools.py
+++ b/molsym/salcs/salc_tools.py
@@ -117,10 +117,12 @@ def character_by_operation(rep_mats):
 def axial_matrix(A, tol=global_tol):
     det = np.linalg.det(A)
 
-    if abs(det - 1.0) < tol:
+    if np.isclose(det, 1.0, atol=tol):
         det = 1.0
-    elif abs(det + 1.0) < tol:
+    elif np.isclose(det, -1.0, atol=tol):
         det = -1.0
+    else:
+        raise ValueError(f"Operation determinant is not ±1: det={det}")
 
     return det * A
 
@@ -151,9 +153,9 @@ def axial_vector_salc_to_string(salc, fxn_set, tol=global_tol):
         if abs(coeff) < tol:
             continue
 
-        if abs(coeff - 1.0) < tol:
+        if np.isclose(coeff, 1.0, atol=tol):
             term = label
-        elif abs(coeff + 1.0) < tol:
+        elif np.isclose(coeff, -1.0, atol=tol):
             term = f"-{label}"
         else:
             term = f"{coeff:.6g}*{label}"
@@ -223,9 +225,9 @@ def internal_coordinate_salc_to_string(salc, fxn_set, tol=global_tol):
             if label is None:
                 label = str(ic)
 
-        if abs(coeff - 1.0) < tol:
+        if np.isclose(coeff, 1.0, atol=tol):
             term = label
-        elif abs(coeff + 1.0) < tol:
+        elif np.isclose(coeff, -1.0, atol=tol):
             term = f"-{label}"
         else:
             term = f"{coeff:.6g}{label}"
@@ -252,9 +254,9 @@ def polynomial_salc_to_string(salc, fxn_set, tol=global_tol, pretty=True):
 
         if label == "1":
             term = f"{coeff:.6g}"
-        elif abs(coeff - 1.0) < tol:
+        elif np.isclose(coeff, 1.0, atol=tol):
             term = label
-        elif abs(coeff + 1.0) < tol:
+        elif np.isclose(coeff, -1.0, atol=tol):
             term = f"-{label}"
         else:
             term = f"{coeff:.6g}*{label}"

--- a/molsym/salcs/salc_tools.py
+++ b/molsym/salcs/salc_tools.py
@@ -1,4 +1,9 @@
 import numpy as np
+from math import comb
+from molsym.salcs.projection_op import ProjectionOp
+from molsym.salcs.axial_vector_functions import AxialVectorFunctions
+from molsym.salcs.polynomial_functions import PolynomialFunctions
+from molsym.molecule import *
 
 def generate_symmetric_partner(symtext, salc, neg_data, data_type="dipole", tol=None):
     """
@@ -103,3 +108,203 @@ def maps_to_negative(symtext, salc, tol=None):
             return True
 
     return False
+
+def character_by_operation(rep_mats):
+    return np.array([np.trace(D) for D in rep_mats], dtype=float)
+
+
+def axial_matrix(A, tol=global_tol):
+    det = np.linalg.det(A)
+
+    if abs(det - 1.0) < tol:
+        det = 1.0
+    elif abs(det + 1.0) < tol:
+        det = -1.0
+
+    return det * A
+
+def analyze_rotations(symtext, print_pretty=True):
+    rep_mats = []
+
+    for i, symel in enumerate(symtext.symels):
+        D = axial_matrix(symel.rrep, global_tol)
+        rep_mats.append(D)
+
+    op_chars = character_by_operation(rep_mats)
+    coeffs = symtext.reduction_coefficients(op_chars, False)
+
+    print("Reduction:")
+    print(format_reduction(coeffs, symtext))
+
+    fxn_set = AxialVectorFunctions(symtext)
+
+    salcs = ProjectionOp(symtext,fxn_set,project_Eckart=False)
+
+    if print_pretty:
+        print_axial_vector_salcs(salcs)
+
+    return salcs
+
+def axial_vector_salc_to_string(salc, fxn_set, tol=global_tol):
+    terms = []
+
+    for coeff, label in zip(salc.coeffs, fxn_set.labels):
+        if abs(coeff) < tol:
+            continue
+
+        if abs(coeff - 1.0) < tol:
+            term = label
+        elif abs(coeff + 1.0) < tol:
+            term = f"-{label}"
+        else:
+            term = f"{coeff:.6g}*{label}"
+
+        terms.append(term)
+
+    if not terms:
+        return "0"
+
+    return " + ".join(terms).replace("+ -", "- ")
+
+
+def print_axial_vector_salcs(salcs):
+    fxn_set = salcs.fxn_set
+
+    for irrep in salcs.irreps:
+        matching = [s for s in salcs.salcs if s.irrep.symbol == irrep.symbol]
+
+        if not matching:
+            continue
+
+        print(f"{irrep.symbol}:")
+
+        for s in matching:
+            expr = axial_vector_salc_to_string(s, fxn_set)
+            print(f"  P_{s.i}{s.j}({s.bfxn}): {expr}")
+
+def construct_rotations(symtext, print_pretty=True):
+    fxn_set = AxialVectorFunctions(symtext)
+    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
+
+    if print_pretty:
+        print_axial_vector_salcs(salcs)
+
+    return salcs
+
+def monomial_label(exp):
+    a, b, c = exp
+    pieces = []
+
+    for label, power in zip(("x", "y", "z"), (a, b, c)):
+        if power == 0:
+            continue
+        elif power == 1:
+            pieces.append(label)
+        else:
+            pieces.append(f"{label}^{power}")
+
+    return "*".join(pieces) if pieces else "1"
+
+def class_characters_from_operation_characters(symtext, op_chars):
+    return np.array([
+        np.mean([
+            op_chars[i]
+            for i, c in enumerate(symtext.symel_to_class_map)
+            if c == class_idx
+        ])
+        for class_idx in range(len(symtext.classes))
+    ])
+
+
+def format_reduction(coeffs, symtext):
+    pieces = []
+
+    for i, mult in enumerate(coeffs):
+        if mult == 0:
+            continue
+
+        symbol = symtext.irreps[i].symbol
+
+        if mult == 1:
+            pieces.append(symbol)
+        else:
+            pieces.append(f"{mult}{symbol}")
+
+    return " + ".join(pieces) if pieces else "0"
+
+
+def construct_polynomials(symtext, degree=2, projector_type="full", print_pretty=True):
+    fxn_set = PolynomialFunctions(symtext, degree=degree)
+    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
+    if print_pretty:
+        print_polynomial_salcs(salcs)
+    return salcs
+
+def polynomial_salc_to_string(salc, fxn_set, tol=global_tol, pretty=True):
+    """
+    Convert one polynomial SALC coefficient vector into a readable polynomial.
+    """
+    terms = []
+
+    for coeff, exp in zip(salc.coeffs, fxn_set.exponents):
+        if abs(coeff) < tol:
+            continue
+
+        label = monomial_label(exp)
+
+        if label == "1":
+            term = f"{coeff:.6g}"
+        elif abs(coeff - 1.0) < tol:
+            term = label
+        elif abs(coeff + 1.0) < tol:
+            term = f"-{label}"
+        else:
+            term = f"{coeff:.6g}*{label}"
+
+        terms.append(term)
+
+    if not terms:
+        return "0"
+
+    out = " + ".join(terms)
+    out = out.replace("+ -", "- ")
+
+    if pretty:
+        out = prettify_polynomial_string(out)
+
+    return out
+
+
+def prettify_polynomial_string(poly):
+    """
+    Minimal string cleanup for character-table-style display.
+    """
+    return (
+        poly
+        .replace("*", "")
+        .replace("^2", "²")
+        .replace("^3", "³")
+        .replace("^4", "⁴")
+        .replace("^5", "⁵")
+    )
+
+
+def print_polynomial_salcs(salcs, pretty=True):
+    """
+    Print polynomial SALCs grouped by irrep.
+    """
+    fxn_set = salcs.fxn_set
+
+    for irrep in salcs.irreps:
+        matching = [s for s in salcs.salcs if s.irrep.symbol == irrep.symbol]
+
+        if not matching:
+            continue
+
+        print(f"{irrep.symbol}:")
+
+        for s in matching:
+            poly = polynomial_salc_to_string(s,fxn_set,pretty=pretty)
+
+            print(f"  P_{s.i}{s.j}({s.bfxn}): {poly}")
+

--- a/molsym/salcs/salc_tools.py
+++ b/molsym/salcs/salc_tools.py
@@ -1,8 +1,5 @@
 import numpy as np
 import re
-from molsym.salcs.projection_op import ProjectionOp
-from molsym.salcs.axial_vector_functions import AxialVectorFunctions
-from molsym.salcs.polynomial_functions import PolynomialFunctions
 from molsym.molecule import global_tol
 
 def generate_symmetric_partner(symtext, salc, neg_data, data_type="dipole", tol=None):
@@ -126,26 +123,6 @@ def axial_matrix(A, tol=global_tol):
 
     return det * A
 
-def analyze_rotations(symtext, print_pretty=True):
-    rep_mats = []
-
-    for i, symel in enumerate(symtext.symels):
-        D = axial_matrix(symel.rrep, global_tol)
-        rep_mats.append(D)
-
-    op_chars = character_by_operation(rep_mats)
-    coeffs = symtext.reduction_coefficients(op_chars, False)
-
-    if print_pretty:
-        print("Reduction:")
-        print(format_reduction(coeffs, symtext))
-
-    fxn_set = AxialVectorFunctions(symtext)
-
-    salcs = ProjectionOp(symtext,fxn_set,project_Eckart=False)
-
-    return salcs
-
 def axial_vector_salc_to_string(salc, fxn_set, tol=global_tol):
     terms = []
 
@@ -198,13 +175,6 @@ def format_reduction(coeffs, symtext):
 
     return " + ".join(pieces) if pieces else "0"
 
-
-def construct_polynomials(symtext, degree=2, print_pretty=True):
-    fxn_set = PolynomialFunctions(symtext, degree=degree)
-    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
-    if print_pretty:
-        print(salcs)
-    return salcs
 
 def internal_coordinate_salc_to_string(salc, fxn_set, tol=global_tol):
     terms = []

--- a/molsym/salcs/salc_tools.py
+++ b/molsym/salcs/salc_tools.py
@@ -68,6 +68,7 @@ def generate_symmetric_partner(symtext, salc, neg_data, data_type="dipole", tol=
         raise ValueError(f"Unsupported data_type: {data_type}")
 
     return pos_data, found_op
+
 def maps_to_negative(symtext, salc, tol=None):
     """
     Test a SALC for +/- displacement equivalence.
@@ -142,10 +143,8 @@ def analyze_rotations(symtext, print_pretty=True):
 
     salcs = ProjectionOp(symtext,fxn_set,project_Eckart=False)
 
-    if print_pretty:
-        print_axial_vector_salcs(salcs)
-
     return salcs
+    return format_reduction(coeffs, symtext)
 
 def axial_vector_salc_to_string(salc, fxn_set, tol=global_tol):
     terms = []
@@ -168,21 +167,6 @@ def axial_vector_salc_to_string(salc, fxn_set, tol=global_tol):
 
     return " + ".join(terms).replace("+ -", "- ")
 
-
-def print_axial_vector_salcs(salcs):
-    fxn_set = salcs.fxn_set
-
-    for irrep in salcs.irreps:
-        matching = [s for s in salcs.salcs if s.irrep.symbol == irrep.symbol]
-
-        if not matching:
-            continue
-
-        print(f"{irrep.symbol}:")
-
-        for s in matching:
-            expr = axial_vector_salc_to_string(s, fxn_set)
-            print(f"  P_{s.i}{s.j}({s.bfxn}): {expr}")
 
 def monomial_label(exp):
     a, b, c = exp
@@ -219,8 +203,42 @@ def construct_polynomials(symtext, degree=2, print_pretty=True):
     fxn_set = PolynomialFunctions(symtext, degree=degree)
     salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
     if print_pretty:
-        print_polynomial_salcs(salcs)
+        print(salcs)
     return salcs
+
+def internal_coordinate_salc_to_string(salc, fxn_set, tol=global_tol):
+    terms = []
+    labels = getattr(fxn_set, "labels", None)
+
+    for idx, (coeff, ic) in enumerate(zip(salc.coeffs, fxn_set.ic_list)):
+        if abs(coeff) < tol:
+            continue
+
+        if labels is not None:
+            label = labels[idx]
+        else:
+            label = getattr(ic, "symbol", None)
+
+            if label is None:
+                label = getattr(ic, "label", None)
+
+            if label is None:
+                label = str(ic)
+
+        if abs(coeff - 1.0) < tol:
+            term = label
+        elif abs(coeff + 1.0) < tol:
+            term = f"-{label}"
+        else:
+            term = f"{coeff:.6g}{label}"
+
+        terms.append(term)
+
+    if not terms:
+        return "0"
+
+    return " + ".join(terms).replace("+ -", "- ")
+
 
 def polynomial_salc_to_string(salc, fxn_set, tol=global_tol, pretty=True):
     """
@@ -269,21 +287,44 @@ def prettify_polynomial_string(poly):
     return poly.replace("*", "")
 
 
-def print_polynomial_salcs(salcs, pretty=True):
+class SALCFormatter:
     """
-    Print polynomial SALCs grouped by irrep.
+    Printable wrapper for SALCs.
+
+    The SALC objects remain generic numerical containers. The FunctionSet
+    decides how coefficient vectors should be rendered.
     """
-    fxn_set = salcs.fxn_set
 
-    for irrep in salcs.irreps:
-        matching = [s for s in salcs.salcs if s.irrep.symbol == irrep.symbol]
+    def __init__(self, salcs):
+        self.salcs = salcs
 
-        if not matching:
-            continue
+    def __str__(self):
+        lines = []
 
-        print(f"{irrep.symbol}:")
+        for irrep in self.salcs.irreps:
+            matching = [
+                s for s in self.salcs.salcs
+                if s.irrep.symbol == irrep.symbol
+            ]
 
-        for s in matching:
-            poly = polynomial_salc_to_string(s,fxn_set,pretty=pretty)
+            if not matching:
+                continue
 
-            print(f"  P_{s.i}{s.j}({s.bfxn}): {poly}")
+            lines.append(f"{irrep.symbol}:")
+
+            for s in matching:
+                if hasattr(self.salcs.fxn_set, "salc_to_string"):
+                    expr = self.salcs.fxn_set.salc_to_string(s)
+                else:
+                    expr = np.array2string(
+                        s.coeffs,
+                        precision=3,
+                        suppress_small=True,
+                    )
+
+                lines.append(f"  P_{s.i}{s.j}({s.bfxn}): {expr}")
+
+        return "\n".join(lines)
+
+def format_salcs(salcs):
+    return SALCFormatter(salcs)

--- a/molsym/salcs/salc_tools.py
+++ b/molsym/salcs/salc_tools.py
@@ -1,9 +1,10 @@
 import numpy as np
 from math import comb
+import re
 from molsym.salcs.projection_op import ProjectionOp
 from molsym.salcs.axial_vector_functions import AxialVectorFunctions
 from molsym.salcs.polynomial_functions import PolynomialFunctions
-from molsym.molecule import *
+from molsym.molecule import global_tol
 
 def generate_symmetric_partner(symtext, salc, neg_data, data_type="dipole", tol=None):
     """
@@ -133,8 +134,9 @@ def analyze_rotations(symtext, print_pretty=True):
     op_chars = character_by_operation(rep_mats)
     coeffs = symtext.reduction_coefficients(op_chars, False)
 
-    print("Reduction:")
-    print(format_reduction(coeffs, symtext))
+    if print_pretty:
+        print("Reduction:")
+        print(format_reduction(coeffs, symtext))
 
     fxn_set = AxialVectorFunctions(symtext)
 
@@ -182,15 +184,6 @@ def print_axial_vector_salcs(salcs):
             expr = axial_vector_salc_to_string(s, fxn_set)
             print(f"  P_{s.i}{s.j}({s.bfxn}): {expr}")
 
-def construct_rotations(symtext, print_pretty=True):
-    fxn_set = AxialVectorFunctions(symtext)
-    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
-
-    if print_pretty:
-        print_axial_vector_salcs(salcs)
-
-    return salcs
-
 def monomial_label(exp):
     a, b, c = exp
     pieces = []
@@ -204,17 +197,6 @@ def monomial_label(exp):
             pieces.append(f"{label}^{power}")
 
     return "*".join(pieces) if pieces else "1"
-
-def class_characters_from_operation_characters(symtext, op_chars):
-    return np.array([
-        np.mean([
-            op_chars[i]
-            for i, c in enumerate(symtext.symel_to_class_map)
-            if c == class_idx
-        ])
-        for class_idx in range(len(symtext.classes))
-    ])
-
 
 def format_reduction(coeffs, symtext):
     pieces = []
@@ -233,7 +215,7 @@ def format_reduction(coeffs, symtext):
     return " + ".join(pieces) if pieces else "0"
 
 
-def construct_polynomials(symtext, degree=2, projector_type="full", print_pretty=True):
+def construct_polynomials(symtext, degree=2, print_pretty=True):
     fxn_set = PolynomialFunctions(symtext, degree=degree)
     salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
     if print_pretty:
@@ -279,14 +261,12 @@ def prettify_polynomial_string(poly):
     """
     Minimal string cleanup for character-table-style display.
     """
-    return (
-        poly
-        .replace("*", "")
-        .replace("^2", "²")
-        .replace("^3", "³")
-        .replace("^4", "⁴")
-        .replace("^5", "⁵")
-    )
+    superscript_map = str.maketrans("0123456789-+", "⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁺")
+
+    for power in sorted(set(re.findall(r"\^[-+]?\d+", poly)), key=len, reverse=True):
+        poly = poly.replace(power, power[1:].translate(superscript_map))
+
+    return poly.replace("*", "")
 
 
 def print_polynomial_salcs(salcs, pretty=True):
@@ -307,4 +287,3 @@ def print_polynomial_salcs(salcs, pretty=True):
             poly = polynomial_salc_to_string(s,fxn_set,pretty=pretty)
 
             print(f"  P_{s.i}{s.j}({s.bfxn}): {poly}")
-

--- a/molsym/symtext/symtext.py
+++ b/molsym/symtext/symtext.py
@@ -7,6 +7,7 @@ from .point_group import PointGroup
 from .general_irrep_mats import pg_to_symels
 from .symtext_helper import get_atom_mapping, rotate_mol_to_symels, get_linear_atom_mapping, get_class_name
 from .multiplication_table import build_mult_table, subgroup_by_name, subgroup_axes, multiply, inverse
+from molsym.salcs.salc_tools import analyze_rotations, construct_polynomials
 class Symtext():
     """
     Fundamental object of MolSym, holds most of the symmetry information of the molecule.
@@ -157,8 +158,7 @@ class Symtext():
         p = np.multiply(dp_vector, self.class_orders)
         return round(p.sum()/(self.order)) > 0
 
-
-    def reduction_coefficients(self, rrep_characters):
+    def reduction_coefficients(self, rrep_characters, by_class=True):
         """
         Return reduction coefficients for the characters of a representation.
 
@@ -168,11 +168,27 @@ class Symtext():
         :rtype: NumPy array of shape (len(self.irreps),)
         """
         out = np.zeros(len(self.irreps), dtype=int)
+    
+        if by_class:
+            class_chars = rrep_characters
+        else:
+            symel_to_class_map = np.array(self.symel_to_class_map)
+            class_chars = np.zeros(
+                len(self.classes),
+                dtype=np.result_type(rrep_characters, float),
+            )
+    
+            for class_idx in range(len(self.classes)):
+                inds = np.where(symel_to_class_map == class_idx)[0]
+                class_chars[class_idx] = np.mean(rrep_characters[inds])
+    
         for irrep_idx, irrep in enumerate(self.irreps):
-            p = np.multiply(rrep_characters, self.class_orders)
-            p = np.multiply(p, self.character_table[irrep_idx,:])
-            out[irrep_idx] = round(p.sum()/(self.order))
+            p = np.multiply(class_chars, self.class_orders)
+            p = np.multiply(p, self.character_table[irrep_idx, :])
+            out[irrep_idx] = round(p.sum() / self.order)
+    
         return out
+
 
     def proj_on_dipole(self, dipole, irrep):
         """
@@ -276,3 +292,9 @@ class Symtext():
                 return self.subgroup_symtext(i)
             except:
                 pass
+
+    def analyze_rotations(self):
+        return analyze_rotations(self)
+
+    def construct_polynomials(self, degree=2, projector_type="projector_type", print_pretty=True):
+        return construct_polynomials(self,degree=degree,projector_type=projector_type,print_pretty=print_pretty)

--- a/molsym/symtext/symtext.py
+++ b/molsym/symtext/symtext.py
@@ -7,7 +7,6 @@ from .point_group import PointGroup
 from .general_irrep_mats import pg_to_symels
 from .symtext_helper import get_atom_mapping, rotate_mol_to_symels, get_linear_atom_mapping, get_class_name
 from .multiplication_table import build_mult_table, subgroup_by_name, subgroup_axes, multiply, inverse
-from molsym.salcs.salc_tools import analyze_rotations, construct_polynomials
 class Symtext():
     """
     Fundamental object of MolSym, holds most of the symmetry information of the molecule.
@@ -162,8 +161,12 @@ class Symtext():
         """
         Return reduction coefficients for the characters of a representation.
 
-        :param rrep_characters: Characters for each class for a representation (reducible or irreducible)
+        :param rrep_characters: Character values as either class-level characters or per-operation characters.
         :type rrep_characters: NumPy array of shape (n,)
+        :param by_class: If True, ``rrep_characters`` is interpreted as one value per class.
+            If False, ``rrep_characters`` is interpreted as one value per symmetry operation and
+            values are averaged within each class before reduction.
+        :type by_class: bool
         :return: Integer array with number of occurences of each irrep. in rrep_characters.
         :rtype: NumPy array of shape (len(self.irreps),)
         """
@@ -292,9 +295,3 @@ class Symtext():
                 return self.subgroup_symtext(i)
             except:
                 pass
-
-    def analyze_rotations(self):
-        return analyze_rotations(self)
-
-    def construct_polynomials(self, degree=2, projector_type="full", print_pretty=True):
-        return construct_polynomials(self,degree=degree,projector_type=projector_type,print_pretty=print_pretty)

--- a/molsym/symtext/symtext.py
+++ b/molsym/symtext/symtext.py
@@ -296,5 +296,5 @@ class Symtext():
     def analyze_rotations(self):
         return analyze_rotations(self)
 
-    def construct_polynomials(self, degree=2, projector_type="projector_type", print_pretty=True):
+    def construct_polynomials(self, degree=2, projector_type="full", print_pretty=True):
         return construct_polynomials(self,degree=degree,projector_type=projector_type,print_pretty=print_pretty)

--- a/test/test_axial_vector_functions.py
+++ b/test/test_axial_vector_functions.py
@@ -88,6 +88,8 @@ def test_axial_vector_salcs_match_character_projectors(molecule):
         P_char *= irrep.d / symtext.order
 
         assert np.allclose(P_salc,P_char,atol=symtext.mol.tol)
+
+
 @pytest.mark.parametrize("molecule", MOLECULES)
 def test_axial_vector_known_reductions(molecule):
     mol = molsym.Molecule.from_file(str(TEST_DIR / "xyz" / f"{molecule}.xyz"))

--- a/test/test_axial_vector_functions.py
+++ b/test/test_axial_vector_functions.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pytest
+import molsym
+
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent
+
+from molsym.salcs.axial_vector_functions import AxialVectorFunctions
+from molsym.salcs.projection_op import ProjectionOp
+
+
+MOLECULES = ["water", "ammonia", "methane"]
+REFERENCE_REDUCTIONS = {
+    "water": {"A_2": 1, "B_1": 1, "B_2": 1},   
+    "ammonia": {"A_2": 1, "E": 1},             
+    "methane": {"T_1": 1},                     
+}
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_axial_vector_fxn_map_is_det_times_rrep(molecule):
+    mol = molsym.Molecule.from_file(str(TEST_DIR / "xyz" / f"{molecule}.xyz"))
+    symtext = molsym.Symtext.from_molecule(mol)
+    fxn_set = AxialVectorFunctions(symtext)
+
+    for sidx, symel in enumerate(symtext.symels):
+        A = np.array(symel.rrep, dtype=float)
+        det = np.linalg.det(A)
+
+        if abs(det - 1.0) < symtext.mol.tol:
+            det = 1.0
+        elif abs(det + 1.0) < symtext.mol.tol:
+            det = -1.0
+
+        expected = (det * A).T
+
+        assert np.allclose(fxn_set.fxn_map[sidx],expected,atol=symtext.mol.tol)
+
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_axial_vector_reduction_matches_salcs(molecule):
+    mol = molsym.Molecule.from_file(str(TEST_DIR / "xyz" / f"{molecule}.xyz"))
+    symtext = molsym.Symtext.from_molecule(mol)
+    fxn_set = AxialVectorFunctions(symtext)
+
+    rep_chars_by_operation = np.array([np.trace(fxn_set.fxn_map[sidx].T) for sidx in range(len(symtext))])
+
+    expected_coeffs = symtext.reduction_coefficients(rep_chars_by_operation,by_class=False)
+
+    salcs = ProjectionOp(symtext,fxn_set,project_Eckart=False)
+
+    actual_coeffs = np.zeros(len(symtext.irreps), dtype=int)
+
+    for irrep_idx, irrep in enumerate(symtext.irreps):
+        n_salcs = sum(salc.irrep.symbol == irrep.symbol for salc in salcs.salcs)
+
+        assert n_salcs % irrep.d == 0
+        actual_coeffs[irrep_idx] = n_salcs // irrep.d
+
+    assert np.array_equal(actual_coeffs, expected_coeffs)
+
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_axial_vector_salcs_match_character_projectors(molecule):
+    mol = molsym.Molecule.from_file(str(TEST_DIR / "xyz" / f"{molecule}.xyz"))
+    symtext = molsym.Symtext.from_molecule(mol)
+    fxn_set = AxialVectorFunctions(symtext)
+
+    salcs = ProjectionOp(symtext,fxn_set,project_Eckart=False)
+
+    T_mats = np.array([fxn_set.fxn_map[sidx].T for sidx in range(len(symtext))])
+
+    for irrep_idx, irrep in enumerate(symtext.irreps):
+        matching = [salc.coeffs for salc in salcs.salcs if salc.irrep.symbol == irrep.symbol]
+
+        if len(matching) == 0:
+            continue
+
+        B = np.column_stack(matching)
+        P_salc = B @ B.T
+
+        P_char = np.zeros((3, 3))
+
+        for sidx in range(len(symtext)):
+            chi = np.trace(symtext.irrep_mats[irrep.symbol][sidx])
+            P_char += chi * T_mats[sidx]
+
+        P_char *= irrep.d / symtext.order
+
+        assert np.allclose(P_salc,P_char,atol=symtext.mol.tol)
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_axial_vector_known_reductions(molecule):
+    mol = molsym.Molecule.from_file(str(TEST_DIR / "xyz" / f"{molecule}.xyz"))
+    symtext = molsym.Symtext.from_molecule(mol)
+
+    fxn_set = AxialVectorFunctions(symtext)
+    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
+
+    actual = {}
+
+    for irrep in symtext.irreps:
+        n_salcs = sum(salc.irrep.symbol == irrep.symbol for salc in salcs.salcs)
+
+        mult = n_salcs // irrep.d
+
+        if mult:
+            actual[irrep.symbol] = mult
+
+    assert actual == REFERENCE_REDUCTIONS[molecule]

--- a/test/test_polynomial_functions.py
+++ b/test/test_polynomial_functions.py
@@ -173,7 +173,7 @@ def subspace_projector(vectors):
 
 
 @pytest.mark.parametrize("molecule, degree", CASES)
-def test_degree_2_polynomial_reductions(molecule, degree):
+def test_polynomial_reductions(molecule, degree):
     symtext = load_symtext(molecule)
     fxn_set = PolynomialFunctions(symtext, degree=degree)
     salcs = ProjectionOp(
@@ -199,7 +199,7 @@ def test_degree_2_polynomial_reductions(molecule, degree):
 
 
 @pytest.mark.parametrize("molecule, degree", CASES)
-def test_degree_2_polynomial_salcs_match_reference_subspaces(molecule, degree):
+def test_polynomial_salcs_match_reference_subspaces(molecule, degree):
     symtext = load_symtext(molecule)
     fxn_set = PolynomialFunctions(symtext, degree=degree)
     salcs = ProjectionOp(
@@ -227,7 +227,7 @@ def test_degree_2_polynomial_salcs_match_reference_subspaces(molecule, degree):
         )
 
 @pytest.mark.parametrize("molecule, degree", CASES)
-def test_degree_2_polynomial_fxn_map_characters_reduce_correctly(molecule, degree):
+def test_polynomial_fxn_map_characters_reduce_correctly(molecule, degree):
     symtext = load_symtext(molecule)
     fxn_set = PolynomialFunctions(symtext, degree=degree)
     op_chars = np.array([

--- a/test/test_polynomial_functions.py
+++ b/test/test_polynomial_functions.py
@@ -1,0 +1,258 @@
+import numpy as np
+import pytest
+import molsym
+
+from pathlib import Path
+
+from molsym.salcs.polynomial_functions import PolynomialFunctions
+from molsym.salcs.projection_op import ProjectionOp
+
+
+TEST_DIR = Path(__file__).resolve().parent
+MOLECULES = ["water", "ammonia", "methane"]
+
+
+REFERENCE_REDUCTIONS = {
+    1: {
+        "water": {"A_1": 1, "B_1": 1, "B_2": 1},
+        "ammonia": {"A_1": 1, "E": 1},
+        "methane": {"T_2": 1},
+    },
+    2: {
+        "water": {"A_1": 3, "A_2": 1, "B_1": 1, "B_2": 1},
+        "ammonia": {"A_1": 2, "E": 2},
+        "methane": {"A_1": 1, "E": 1, "T_2": 1},
+    },
+    3: {
+        "water": {"A_1": 3, "A_2": 1, "B_1": 3, "B_2": 3},
+        "ammonia": {"A_1": 3, "A_2": 1, "E": 3},
+        "methane": {"A_1": 1, "T_1": 1, "T_2": 2},
+    },
+}
+
+
+REFERENCE_FUNCTIONS = {
+    1: {
+        # basis: x, y, z
+        "water": {
+            "A_1": [[0, 0, 1]],
+            "B_1": [[1, 0, 0]],
+            "B_2": [[0, 1, 0]],
+        },
+        "ammonia": {
+            "A_1": [[0, 0, 1]],
+            "E": [
+                [1, 0, 0],
+                [0, 1, 0],
+            ],
+        },
+        "methane": {
+            "T_2": [
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ],
+        },
+    },
+
+    2: {
+        # basis: x², xy, xz, y², yz, z²
+        "water": {
+            "A_1": [
+                [1, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 1],
+            ],
+            "A_2": [[0, 1, 0, 0, 0, 0]],
+            "B_1": [[0, 0, 1, 0, 0, 0]],
+            "B_2": [[0, 0, 0, 0, 1, 0]],
+        },
+        "ammonia": {
+            "A_1": [
+                [1, 0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 1],
+            ],
+            "E": [
+                [1, 0, 0, -1, 0, 0],
+                [0, 1, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0],
+            ],
+        },
+        "methane": {
+            "A_1": [[1, 0, 0, 1, 0, 1]],
+            "E": [
+                [-1, 0, 0, -1, 0, 2],
+                [1, 0, 0, -1, 0, 0],
+            ],
+            "T_2": [
+                [0, 1, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0],
+            ],
+        },
+    },
+
+    3: {
+        # basis: x³, x²y, x²z, xy², xyz, xz², y³, y²z, yz², z³
+        "water": {
+            "A_1": [
+                [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],  # x²z
+                [0, 0, 0, 0, 0, 0, 0, 1, 0, 0],  # y²z
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  # z³
+            ],
+            "A_2": [
+                [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],  # xyz
+            ],
+            "B_1": [
+                [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],  # x³
+                [0, 0, 0, 1, 0, 0, 0, 0, 0, 0],  # xy²
+                [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],  # xz²
+            ],
+            "B_2": [
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],  # x²y
+                [0, 0, 0, 0, 0, 0, 1, 0, 0, 0],  # y³
+                [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],  # yz²
+            ],
+        },
+        "ammonia": {
+            "A_1": [
+                [1, 0, 0, -3, 0, 0, 0, 0, 0, 0],  # x³ - 3xy²
+                [0, 0, 1, 0, 0, 0, 0, 1, 0, 0],   # x²z + y²z
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],   # z³
+            ],
+            "A_2": [
+                [0, 3, 0, 0, 0, 0, -1, 0, 0, 0],  # 3x²y - y³
+            ],
+            "E": [
+                [1, 0, 0, 1, 0, 0, 0, 0, 0, 0],   # x³ + xy²
+                [0, 1, 0, 0, 0, 0, 1, 0, 0, 0],   # x²y + y³
+                [0, 0, 1, 0, 0, 0, 0, -1, 0, 0],  # x²z - y²z
+                [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],   # xyz
+                [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],   # xz²
+                [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],   # yz²
+            ],
+        },
+        "methane": {
+            "A_1": [
+                [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],   # xyz
+            ],
+            "T_1": [
+                [0, 0, 0, 1, 0, -1, 0, 0, 0, 0],  # x(y²-z²)
+                [0, -1, 0, 0, 0, 0, 0, 0, 1, 0],  # y(z²-x²)
+                [0, 0, 1, 0, 0, 0, 0, -1, 0, 0],  # z(x²-y²)
+            ],
+            "T_2": [
+                [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],   # x³
+                [0, 0, 0, 0, 0, 0, 1, 0, 0, 0],   # y³
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],   # z³
+                [0, 0, 0, 1, 0, 1, 0, 0, 0, 0],   # x(y²+z²)
+                [0, 1, 0, 0, 0, 0, 0, 0, 1, 0],   # y(x²+z²)
+                [0, 0, 1, 0, 0, 0, 0, 1, 0, 0],   # z(x²+y²)
+            ],
+        },
+    },
+}
+
+CASES = [
+    (molecule, degree)
+    for molecule in MOLECULES
+    for degree in [1, 2, 3]
+]
+
+def load_symtext(molecule):
+    xyz = TEST_DIR / "xyz" / f"{molecule}.xyz"
+    mol = molsym.Molecule.from_file(str(xyz))
+    return molsym.Symtext.from_molecule(mol)
+
+
+def subspace_projector(vectors):
+    B = np.column_stack([np.array(v, dtype=float) for v in vectors])
+    Q, _ = np.linalg.qr(B)
+    return Q @ Q.T
+
+
+@pytest.mark.parametrize("molecule, degree", CASES)
+def test_degree_2_polynomial_reductions(molecule, degree):
+    symtext = load_symtext(molecule)
+    fxn_set = PolynomialFunctions(symtext, degree=degree)
+    salcs = ProjectionOp(
+        symtext,
+        fxn_set,
+        project_Eckart=False,
+    )
+
+    actual = {}
+
+    for irrep in symtext.irreps:
+        n_salcs = sum(
+            salc.irrep.symbol == irrep.symbol
+            for salc in salcs.salcs
+        )
+
+        mult = n_salcs // irrep.d
+
+        if mult:
+            actual[irrep.symbol] = mult
+
+    assert actual == REFERENCE_REDUCTIONS[degree][molecule]
+
+
+@pytest.mark.parametrize("molecule, degree", CASES)
+def test_degree_2_polynomial_salcs_match_reference_subspaces(molecule, degree):
+    symtext = load_symtext(molecule)
+    fxn_set = PolynomialFunctions(symtext, degree=degree)
+    salcs = ProjectionOp(
+        symtext,
+        fxn_set,
+        project_Eckart=False,
+    )
+
+    for irrep_symbol, reference_vectors in REFERENCE_FUNCTIONS[degree][molecule].items():
+        matching = [
+            salc.coeffs
+            for salc in salcs.salcs
+            if salc.irrep.symbol == irrep_symbol
+        ]
+
+        assert matching, f"No SALCs found for {irrep_symbol}"
+
+        P_ref = subspace_projector(reference_vectors)
+        P_test = subspace_projector(matching)
+
+        assert np.allclose(
+            P_test,
+            P_ref,
+            atol=10 * symtext.mol.tol,
+        )
+
+@pytest.mark.parametrize("molecule, degree", CASES)
+def test_degree_2_polynomial_fxn_map_characters_reduce_correctly(molecule, degree):
+    symtext = load_symtext(molecule)
+    fxn_set = PolynomialFunctions(symtext, degree=degree)
+    op_chars = np.array([
+        np.trace(fxn_set.fxn_map[sidx].T)
+        for sidx in range(len(symtext))
+    ])
+    expected_coeffs = symtext.reduction_coefficients(
+        op_chars,
+        by_class=False,
+    )
+
+    salcs = ProjectionOp(
+        symtext,
+        fxn_set,
+        project_Eckart=False,
+    )
+
+    actual_coeffs = np.zeros(len(symtext.irreps), dtype=int)
+    for irrep_idx, irrep in enumerate(symtext.irreps):
+        n_salcs = sum(
+            salc.irrep.symbol == irrep.symbol
+            for salc in salcs.salcs
+        )
+
+        assert n_salcs % irrep.d == 0
+        actual_coeffs[irrep_idx] = n_salcs // irrep.d
+
+    assert np.array_equal(actual_coeffs, expected_coeffs)

--- a/test/test_salc_tools.py
+++ b/test/test_salc_tools.py
@@ -3,6 +3,12 @@ import numpy as np
 import molsym
 from pathlib import Path
 
+from molsym.salcs.salc_tools import (axial_matrix,character_by_operation,format_reduction,monomial_label,prettify_polynomial_string,polynomial_salc_to_string,print_polynomial_salcs)
+
+from molsym.salcs.polynomial_functions import PolynomialFunctions
+from molsym.salcs.projection_op import ProjectionOp
+from molsym.molecule import *
+
 TEST_DIR = Path(__file__).resolve().parent
 
 reference_data = {
@@ -492,3 +498,249 @@ def test_maps_to_negative_molecule_tolerance():
     )
 
     assert result is True
+
+MOLECULES = ["water", "ammonia", "methane"]
+REFERENCE_ROTATION_ANALYSIS = {
+    "water": {
+        "reduction": "A_2 + B_1 + B_2",
+        "functions": {
+            "A_2": ["Rz"],
+            "B_1": ["Ry"],
+            "B_2": ["Rx"],
+        },
+    },
+
+    "ammonia": {
+        "reduction": "A_2 + E",
+        "functions": {
+            "A_2": ["Rz"],
+            "E": ["Rx", "Ry"],
+        },
+    },
+
+    "methane": {
+        "reduction": "T_1",
+        "functions": {
+            "T_1": ["Rx", "Ry", "Rz"],
+        },
+    },
+}
+
+REFERENCE_DEGREE2_PRETTY = {
+    "water": {
+        "A_1": [
+            "x²",
+            "y²",
+            "z²",
+        ],
+        "A_2": [
+            "xy",
+        ],
+        "B_1": [
+            "xz",
+        ],
+        "B_2": [
+            "yz",
+        ],
+    },
+
+    "ammonia": {
+        "A_1": [
+            "0.707107x² + 0.707107y²",
+            "z²",
+        ],
+        "E": [
+            "0.707107x² - 0.707107y²",
+            "-xy",
+            "xz",
+            "yz",
+        ],
+    },
+
+    "methane": {
+        "A_1": [
+            "0.57735x² + 0.57735y² + 0.57735z²",
+        ],
+
+        "E": [
+            "0.408248x² + 0.408248y² - 0.816497z²",
+            "-0.707107x² + 0.707107y²",
+        ],
+
+        "T_2": [
+            "yz",
+            "xz",
+            "xy",
+        ],
+    },
+}
+
+def load_symtext(molecule):
+    xyz = TEST_DIR / "xyz" / f"{molecule}.xyz"
+    mol = molsym.Molecule.from_file(str(xyz))
+    return molsym.Symtext.from_molecule(mol)
+
+
+def test_axial_matrix_proper_rotation():
+    A = np.eye(3)
+    D = axial_matrix(A, tol=global_tol)
+    assert np.allclose(D, np.eye(3))
+
+
+def test_axial_matrix_improper_operation():
+    A = np.diag([1.0, 1.0, -1.0])
+    D = axial_matrix(A, tol=global_tol)
+    assert np.allclose(D, -A)
+
+
+def test_character_by_operation():
+    mats = np.array([
+        np.eye(3),
+        -np.eye(3),
+    ])
+
+    chars = character_by_operation(mats)
+
+    assert np.allclose(chars, [3.0, -3.0])
+
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_format_reduction_smoke(molecule):
+    symtext = load_symtext(molecule)
+
+    coeffs = np.zeros(len(symtext.irreps), dtype=int)
+    coeffs[0] = 1
+
+    reduction = format_reduction(coeffs, symtext)
+
+    assert symtext.irreps[0].symbol in reduction
+
+
+def test_monomial_label():
+    assert monomial_label((1, 0, 0)) == "x"
+    assert monomial_label((0, 1, 0)) == "y"
+    assert monomial_label((0, 0, 1)) == "z"
+    assert monomial_label((2, 0, 0)) == "x^2"
+    assert monomial_label((1, 1, 0)) == "x*y"
+    assert monomial_label((0, 0, 0)) == "1"
+
+
+def test_prettify_polynomial_string():
+    raw = "1*x^2 + 2*x*y - 3*z^3"
+    pretty = prettify_polynomial_string(raw)
+
+    assert "*" not in pretty
+    assert "x²" in pretty
+    assert "z³" in pretty
+
+
+def test_polynomial_salc_to_string_degree2_ammonia():
+    symtext = load_symtext("ammonia")
+    fxn_set = PolynomialFunctions(symtext, degree=2)
+
+    salcs = ProjectionOp(
+        symtext,
+        fxn_set,
+        project_Eckart=False,
+    )
+
+    strings = [
+        polynomial_salc_to_string(salc, fxn_set)
+        for salc in salcs.salcs
+    ]
+
+    joined = "\n".join(strings)
+
+    assert "z²" in joined
+    assert "xz" in joined
+    assert "yz" in joined
+
+
+def test_print_polynomial_salcs_degree2_ammonia(capsys):
+    symtext = load_symtext("ammonia")
+    fxn_set = PolynomialFunctions(symtext, degree=2)
+
+    salcs = ProjectionOp(
+        symtext,
+        fxn_set,
+        project_Eckart=False,
+    )
+
+    print_polynomial_salcs(salcs)
+
+    captured = capsys.readouterr().out
+
+    assert "A_1:" in captured
+    assert "E:" in captured
+    assert "z²" in captured
+    assert "xz" in captured
+    assert "yz" in captured
+
+
+def test_analyze_rotations_ammonia(capsys):
+    symtext = load_symtext("ammonia")
+
+    symtext.analyze_rotations()
+
+    captured = capsys.readouterr().out
+
+    assert "Reduction:" in captured
+    assert "A_2 + E" in captured
+    assert "Rz" in captured
+    assert "Rx" in captured
+    assert "Ry" in captured
+
+
+def test_construct_polynomials_degree2_ammonia(capsys):
+    symtext = load_symtext("ammonia")
+
+    symtext.construct_polynomials(
+        degree=2,
+        projector_type="full",
+        print_pretty=True,
+    )
+
+    captured = capsys.readouterr().out
+
+    assert "A_1:" in captured
+    assert "E:" in captured
+    assert "z²" in captured
+    assert "xz" in captured
+    assert "yz" in captured
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_rotation_analysis_reference(capsys, molecule):
+    symtext = load_symtext(molecule)
+
+    symtext.analyze_rotations()
+
+    captured = capsys.readouterr().out
+
+    ref = REFERENCE_ROTATION_ANALYSIS[molecule]
+
+    assert ref["reduction"] in captured
+
+    for irrep, functions in ref["functions"].items():
+        assert f"{irrep}:" in captured
+
+        for fxn in functions:
+            assert fxn in captured
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_degree2_polynomial_pretty_reference(capsys, molecule):
+    symtext = load_symtext(molecule)
+
+    symtext.construct_polynomials(
+        degree=2,
+        print_pretty=True,
+    )
+
+    captured = capsys.readouterr().out
+
+    ref = REFERENCE_DEGREE2_PRETTY[molecule]
+
+    for irrep, functions in ref.items():
+        assert f"{irrep}:" in captured
+
+        for fxn in functions:
+            assert fxn in captured

--- a/test/test_salc_tools.py
+++ b/test/test_salc_tools.py
@@ -4,10 +4,8 @@ import molsym
 from pathlib import Path
 
 from molsym.salcs.salc_tools import (
-    analyze_rotations,
     axial_matrix,
     character_by_operation,
-    construct_polynomials,
     format_reduction,
     monomial_label,
     prettify_polynomial_string,
@@ -636,7 +634,12 @@ def test_prettify_polynomial_string():
 def test_rotation_analysis_reference(capsys, molecule):
     symtext = load_symtext(molecule)
 
-    analyze_rotations(symtext)
+    rep_mats = [axial_matrix(symel.rrep, global_tol) for symel in symtext.symels]
+    op_chars = character_by_operation(rep_mats)
+    coeffs = symtext.reduction_coefficients(op_chars, False)
+
+    print("Reduction:")
+    print(format_reduction(coeffs, symtext))
 
     captured = capsys.readouterr().out
 

--- a/test/test_salc_tools.py
+++ b/test/test_salc_tools.py
@@ -12,10 +12,11 @@ from molsym.salcs.salc_tools import (
     monomial_label,
     prettify_polynomial_string,
     polynomial_salc_to_string,
-    print_polynomial_salcs,
 )
 
+from molsym.salcs.axial_vector_functions import AxialVectorFunctions
 from molsym.salcs.polynomial_functions import PolynomialFunctions
+from molsym.salcs.internal_coordinates import InternalCoordinates
 from molsym.salcs.projection_op import ProjectionOp
 from molsym.molecule import global_tol
 
@@ -614,18 +615,6 @@ def test_character_by_operation():
     assert np.allclose(chars, [3.0, -3.0])
 
 
-@pytest.mark.parametrize("molecule", MOLECULES)
-def test_format_reduction_smoke(molecule):
-    symtext = load_symtext(molecule)
-
-    coeffs = np.zeros(len(symtext.irreps), dtype=int)
-    coeffs[0] = 1
-
-    reduction = format_reduction(coeffs, symtext)
-
-    assert symtext.irreps[0].symbol in reduction
-
-
 def test_monomial_label():
     assert monomial_label((1, 0, 0)) == "x"
     assert monomial_label((0, 1, 0)) == "y"
@@ -643,81 +632,6 @@ def test_prettify_polynomial_string():
     assert "x²" in pretty
     assert "z³" in pretty
 
-
-def test_polynomial_salc_to_string_degree2_ammonia():
-    symtext = load_symtext("ammonia")
-    fxn_set = PolynomialFunctions(symtext, degree=2)
-
-    salcs = ProjectionOp(
-        symtext,
-        fxn_set,
-        project_Eckart=False,
-    )
-
-    strings = [
-        polynomial_salc_to_string(salc, fxn_set)
-        for salc in salcs.salcs
-    ]
-
-    joined = "\n".join(strings)
-
-    assert "z²" in joined
-    assert "xz" in joined
-    assert "yz" in joined
-
-
-def test_print_polynomial_salcs_degree2_ammonia(capsys):
-    symtext = load_symtext("ammonia")
-    fxn_set = PolynomialFunctions(symtext, degree=2)
-
-    salcs = ProjectionOp(
-        symtext,
-        fxn_set,
-        project_Eckart=False,
-    )
-
-    print_polynomial_salcs(salcs)
-
-    captured = capsys.readouterr().out
-
-    assert "A_1:" in captured
-    assert "E:" in captured
-    assert "z²" in captured
-    assert "xz" in captured
-    assert "yz" in captured
-
-
-def test_analyze_rotations_ammonia(capsys):
-    symtext = load_symtext("ammonia")
-
-    analyze_rotations(symtext)
-
-    captured = capsys.readouterr().out
-
-    assert "Reduction:" in captured
-    assert "A_2 + E" in captured
-    assert "Rz" in captured
-    assert "Rx" in captured
-    assert "Ry" in captured
-
-
-def test_construct_polynomials_degree2_ammonia(capsys):
-    symtext = load_symtext("ammonia")
-
-    construct_polynomials(
-        symtext,
-        degree=2,
-        print_pretty=True,
-    )
-
-    captured = capsys.readouterr().out
-
-    assert "A_1:" in captured
-    assert "E:" in captured
-    assert "z²" in captured
-    assert "xz" in captured
-    assert "yz" in captured
-
 @pytest.mark.parametrize("molecule", MOLECULES)
 def test_rotation_analysis_reference(capsys, molecule):
     symtext = load_symtext(molecule)
@@ -728,7 +642,20 @@ def test_rotation_analysis_reference(capsys, molecule):
 
     ref = REFERENCE_ROTATION_ANALYSIS[molecule]
 
+    assert "Reduction:" in captured
     assert ref["reduction"] in captured
+
+@pytest.mark.parametrize("molecule", MOLECULES)
+def test_axial_vector_pretty_reference(capsys, molecule):
+    symtext = load_symtext(molecule)
+
+    fxn_set = AxialVectorFunctions(symtext)
+    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
+    fxn_set.salc_print_style = "pretty"
+    print(salcs)
+    captured = capsys.readouterr().out
+
+    ref = REFERENCE_ROTATION_ANALYSIS[molecule]
 
     for irrep, functions in ref["functions"].items():
         assert f"{irrep}:" in captured
@@ -736,16 +663,17 @@ def test_rotation_analysis_reference(capsys, molecule):
         for fxn in functions:
             assert fxn in captured
 
+
 @pytest.mark.parametrize("molecule", MOLECULES)
 def test_degree2_polynomial_pretty_reference(capsys, molecule):
     symtext = load_symtext(molecule)
 
-    construct_polynomials(
-        symtext,
-        degree=2,
-        print_pretty=True,
-    )
+    fxn_set = PolynomialFunctions(symtext, degree=2)
+    salcs = ProjectionOp(symtext, fxn_set, project_Eckart=False)
 
+    fxn_set.salc_print_style = "pretty"
+
+    print(salcs)
     captured = capsys.readouterr().out
 
     ref = REFERENCE_DEGREE2_PRETTY[molecule]
@@ -755,3 +683,59 @@ def test_degree2_polynomial_pretty_reference(capsys, molecule):
 
         for fxn in functions:
             assert fxn in captured
+
+INTERNAL_COORDINATE_DEFS = {
+    "water": [
+        [[0, 1], "R1"],
+        [[0, 2], "R2"],
+        [[1, 0, 2], "A1"],
+    ],
+    "ammonia": [
+        [[0, 1], "R1"],
+        [[0, 2], "R2"],
+        [[0, 3], "R3"],
+        [[1, 0, 2], "A1"],
+        [[2, 0, 3], "A2"],
+        [[3, 0, 1], "A3"],
+    ],
+}
+
+INTERNAL_COORDINATE_PRETTY_REFERENCE = {
+    "water": [
+        "A_1:",
+        "P_00(0): 0.707107R1 + 0.707107R2",
+        "P_00(2): A1",
+        "B_2:",
+        "P_00(0): 0.707107R1 - 0.707107R2",
+    ],
+    "ammonia": [
+        "A_1:",
+        "P_00(0): 0.57735R1 + 0.57735R2 + 0.57735R3",
+        "P_00(3): 0.57735A1 + 0.57735A2 + 0.57735A3",
+        "E:",
+        "P_00(0): 0.408248R1 + 0.408248R2 - 0.816497R3",
+        "P_10(0): 0.707107R1 - 0.707107R2",
+        "P_00(3): 0.816497A1 - 0.408248A2 - 0.408248A3",
+        "P_10(3): -0.707107A2 + 0.707107A3",
+    ],
+}
+
+@pytest.mark.parametrize("molecule", ["water", "ammonia"])
+def test_internal_coordinate_symbol_pretty_reference(capsys, molecule):
+    symtext = load_symtext(molecule)
+
+    fxn_set = InternalCoordinates(
+        symtext,
+        INTERNAL_COORDINATE_DEFS[molecule],
+    )
+
+    salcs = ProjectionOp(symtext, fxn_set)
+
+    fxn_set.salc_print_style = "pretty"
+
+    print(salcs)
+    captured = capsys.readouterr().out
+
+    for expected in INTERNAL_COORDINATE_PRETTY_REFERENCE[molecule]:
+        assert expected in captured
+

--- a/test/test_salc_tools.py
+++ b/test/test_salc_tools.py
@@ -3,11 +3,21 @@ import numpy as np
 import molsym
 from pathlib import Path
 
-from molsym.salcs.salc_tools import (axial_matrix,character_by_operation,format_reduction,monomial_label,prettify_polynomial_string,polynomial_salc_to_string,print_polynomial_salcs)
+from molsym.salcs.salc_tools import (
+    analyze_rotations,
+    axial_matrix,
+    character_by_operation,
+    construct_polynomials,
+    format_reduction,
+    monomial_label,
+    prettify_polynomial_string,
+    polynomial_salc_to_string,
+    print_polynomial_salcs,
+)
 
 from molsym.salcs.polynomial_functions import PolynomialFunctions
 from molsym.salcs.projection_op import ProjectionOp
-from molsym.molecule import *
+from molsym.molecule import global_tol
 
 TEST_DIR = Path(__file__).resolve().parent
 
@@ -680,7 +690,7 @@ def test_print_polynomial_salcs_degree2_ammonia(capsys):
 def test_analyze_rotations_ammonia(capsys):
     symtext = load_symtext("ammonia")
 
-    symtext.analyze_rotations()
+    analyze_rotations(symtext)
 
     captured = capsys.readouterr().out
 
@@ -694,9 +704,9 @@ def test_analyze_rotations_ammonia(capsys):
 def test_construct_polynomials_degree2_ammonia(capsys):
     symtext = load_symtext("ammonia")
 
-    symtext.construct_polynomials(
+    construct_polynomials(
+        symtext,
         degree=2,
-        projector_type="full",
         print_pretty=True,
     )
 
@@ -712,7 +722,7 @@ def test_construct_polynomials_degree2_ammonia(capsys):
 def test_rotation_analysis_reference(capsys, molecule):
     symtext = load_symtext(molecule)
 
-    symtext.analyze_rotations()
+    analyze_rotations(symtext)
 
     captured = capsys.readouterr().out
 
@@ -730,7 +740,8 @@ def test_rotation_analysis_reference(capsys, molecule):
 def test_degree2_polynomial_pretty_reference(capsys, molecule):
     symtext = load_symtext(molecule)
 
-    symtext.construct_polynomials(
+    construct_polynomials(
+        symtext,
         degree=2,
         print_pretty=True,
     )


### PR DESCRIPTION
This PR includes:

- axial-vector SALCs (rotational symmetry functions)
- homogeneous Cartesian polynomial SALCs and pretty-printing utilities for symbolic SALC output
- Symtext convenience wrappers for rotational and polynomial analysis,
- pytest coverage, tested on water, ammonia, and methane

One architectural concern: I’m not fully convinced the new printing/analysis utilities belong in salc_tools.py. Some of this functionality may fit more naturally alongside character table as long as the symtext has been generated.

Example usage:

```
import molsym

mol = molsym.Molecule.from_file("test/xyz/ammonia.xyz")
symtext = molsym.Symtext.from_molecule(mol)

symtext.analyze_rotations()
symtext.construct_polynomials(degree=2,print_pretty=True)
```