### PR TITLE
Make qcelemental an optional dependency

### DIFF
--- a/molsym/molecule.py
+++ b/molsym/molecule.py
@@ -1,5 +1,4 @@
 import numpy as np
-import qcelemental as qcel
 from dataclasses import dataclass
 from copy import deepcopy
 import sys
@@ -62,6 +61,7 @@ class Molecule():
         :type schema: dict
         :rtype: molsym.Molecule
         """
+        import qcelemental as qcel
         atoms = schema["symbols"]
         natoms = len(atoms)
         coords = np.reshape(schema["geometry"], (natoms,3))
@@ -96,9 +96,10 @@ class Molecule():
         :type fn: str
         :rtype: molsym.Molecule
         """
+        import qcelemental as qcel
         with open(fn, "r") as lfn:
             strang = lfn.read()
-        
+
         schema = qcel.models.Molecule.from_data(strang).dict()
         if keep_angstrom:
             schema["geometry"] *= qcel.constants.bohr2angstroms
@@ -114,6 +115,7 @@ class Molecule():
         :type schema: dict
         :rtype: molsym.Molecule
         """
+        import qcelemental as qcel
         atoms = schema["elem"] # was symbols
         natoms = len(atoms)
         coords = np.reshape(schema["geom"], (natoms,3)) # was geometry
@@ -124,6 +126,7 @@ class Molecule():
         return cls(atoms, coords, masses)
 
     def to_xyz_string(self, already_angstrom=False):
+        import qcelemental as qcel
         # Will save xyz in Angstrom, undoing the previous
         # Ang->Bohr from Molecule.from_schema
         if already_angstrom:

--- a/molsym/symtext/symtext.py
+++ b/molsym/symtext/symtext.py
@@ -1,6 +1,5 @@
 import numpy as np
 import re
-import qcelemental as qcel
 from molsym.molecule import Molecule
 from molsym import find_point_group
 from .point_group import PointGroup
@@ -87,6 +86,7 @@ class Symtext():
         :type fn: str
         :rtype: molsym.Symtext
         """
+        import qcelemental as qcel
         with open(fn, "r") as lfn:
             strang = lfn.read()
         schema = qcel.models.Molecule.from_data(strang).dict()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ readme = "README.md"
 requires-python = ">=3.9"
 [options]
 install_requires = [
-    "numpy >= 1.23.4",
+    "numpy >= 1.23.4"
+    ]
+
+[options.extras_require]
+qcel = [
     "qcelemental >= 0.25.1"
     ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ pytest==7.2.2
 pytest-cov==4.0.0
 tomli==2.0.1
 numpy >= 1.23.4
+# qcelemental is optional; install it (or `molsym[qcel]`) for the file/schema/Psi4 loaders.
 qcelemental >= 0.25.1
 


### PR DESCRIPTION
Closes #64. Made with Claude.

***

The core in-memory path (point-group detection + SALC generation) only needs numpy. qcelemental was imported at module top in molecule.py and symtext/symtext.py but is used solely by the file/schema/Psi4 loaders and serializer and one mass lookup, never by the core path.

- molecule.py: drop top-level `import qcelemental as qcel`; import it locally in from_schema, from_file, from_psi4_schema, and to_xyz_string (the only qcel users; from_psi4_molecule uses no qcel).
- symtext/symtext.py: drop top-level import; import locally in from_file.
- pyproject.toml: move qcelemental into an optional `qcel` extra so `pip install molsym` is numpy-only and `pip install molsym[qcel]` restores the loaders.
- requirements.txt: note qcelemental is optional.

Now `import molsym` plus point-group/SALC generation works with only numpy installed (no qcelemental/pydantic/pint)