### PR TITLE
Add PyPI publishing workflows and fix packaging metadata

### DIFF
--- a/.github/workflows/build-dist.yaml
+++ b/.github/workflows/build-dist.yaml
@@ -1,0 +1,41 @@
+name: Build distributions
+on:
+  # Validate packaging changes on PRs and the default branch, and build the
+  # release artifacts when a GitHub Release is published. The Publish workflow
+  # reacts to a successful release build via workflow_run and uploads the
+  # result to PyPI.
+  pull_request:
+    paths:
+      - '.github/workflows/build-dist.yaml'
+      - 'pyproject.toml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/build-dist.yaml'
+      - 'pyproject.toml'
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build
+    if: github.repository == 'NASymmetry/MolSym' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+      # MolSym is pure Python, so a single universal sdist + wheel pair works on
+      # every platform and Python version.
+      - name: Build sdist and wheel
+        run: python -m build --outdir dist
+      - name: Check metadata
+        run: twine check --strict dist/*
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: molsym-dist
+          path: dist/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,57 @@
+name: Publish
+# Reacts to a completed "Build distributions" run rather than triggering on the
+# release directly. Using workflow_run keeps this privileged workflow off of
+# pull requests entirely, so PRs never show a skipped publish check. The job
+# only acts when the build it is reacting to was for a published GitHub Release
+# that succeeded.
+on:
+  workflow_run:
+    workflows: [Build distributions]
+    types: [completed]
+jobs:
+  publish:
+    name: Publish to PyPI and GitHub Release
+    if: >-
+      github.repository == 'NASymmetry/MolSym' &&
+      github.event.workflow_run.event == 'release' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/MolSym/
+    permissions:
+      # Mint a short-lived OIDC token for PyPI trusted publishing; no API token
+      # secret is stored in the repository.
+      id-token: write
+      # Attach the built distributions to the GitHub Release.
+      contents: write
+      # Download the build artifacts from the triggering workflow run.
+      actions: read
+    steps:
+      # Artifacts live in the triggering run, so they must be fetched by its id
+      # (workflow_run does not carry them across automatically).
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: molsym-dist
+          path: dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # PyPI uploads are immutable, but the GitHub Release asset step below can
+      # still fail transiently. skip-existing keeps the whole workflow safely
+      # re-runnable: a re-run no-ops the already-published files instead of
+      # erroring, so it can get through to (re)attach the release assets.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+      # Mirror the published distributions onto the GitHub Release alongside
+      # GitHub's auto-generated source archives. The release build ran on the
+      # tag, so the triggering run's head_branch is the release tag. GH_REPO
+      # lets gh find the repo without a checkout.
+      - name: Attach distributions to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.workflow_run.head_branch }}
+        run: gh release upload "$TAG" dist/* --clobber

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,29 +1,36 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
-[metadata]
+[project]
 name = "MolSym"
 version = "0.2.1"
-authors = [
-    "Stephen Goodlett <smg13363@uga.edu>",
-    "Nate Kitzmiller <nathaniel.kitzmiller@uga.edu>",
-    ]
 description = "A program for molecular symmetry detection and SALC construction"
-long_description = "file: README.md"
-license = "MIT"
-classifiers = [
-    "Programming Language :: Python :: 3"
-    ]
 readme = "README.md"
 requires-python = ">=3.9"
-[options]
-install_requires = [
-    "numpy >= 1.23.4"
-    ]
+license = "MIT"
+authors = [
+    { name = "Stephen Goodlett", email = "smg13363@uga.edu" },
+    { name = "Nate Kitzmiller", email = "nathaniel.kitzmiller@uga.edu" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "numpy >= 1.23.4",
+]
 
-[options.extras_require]
+# qcelemental is optional so the core molsym install/API path stays NumPy-only
+# (carried forward from #65). Install with `pip install MolSym[qcel]` to enable
+# the qcelemental-backed features.
+[project.optional-dependencies]
 qcel = [
-    "qcelemental >= 0.25.1"
-    ]
+    "qcelemental >= 0.25.1",
+]
 
+[project.urls]
+Homepage = "https://github.com/NASymmetry/MolSym"
+Documentation = "https://molsym.readthedocs.io"
+
+[tool.setuptools.packages.find]
+include = ["molsym*"]


### PR DESCRIPTION
Addresses #63. Made with Claude. I’m making this so Pyberny can use Molsym as a required dependency.

This PR largely automatizes publishing on PyPI, but you’d still need to do a few things yourself. I’m happy to help.

1. Make a PyPI account or find someone who has one
2. Authorize this repo to publish on PyPI
3. Create a corresponding env on Github
4. Make a Github release

The workflows take care of the rest.

***

Set up a two-stage release pipeline:

- build-dist.yaml ("Build distributions") builds the sdist + wheel, validates metadata with `twine check --strict`, and uploads them as a workflow artifact. Runs on packaging-related PRs/pushes, on published releases, and on manual dispatch.
- publish.yaml ("Publish") reacts to a successful release build via workflow_run, publishes to PyPI using OIDC trusted publishing (no stored token), and attaches the distributions to the GitHub Release. Gated on the release event succeeding so it never runs on pull requests.

The repository guards target the upstream NASymmetry/MolSym slug, since this branch is intended to be merged there.

Also fix pyproject.toml, which used setup.cfg-style [metadata]/[options] tables that setuptools' pyproject backend ignores entirely -- builds were producing a metadata-less molsym-0.0.0. Convert to a valid PEP 621 [project] table so the package builds as MolSym 0.2.1 with its declared authors, dependencies, and classifiers.