### PR TITLE
Allow project_Eckart to select translational- or rotational-only projection

### DIFF
--- a/molsym/salcs/projection_op.py
+++ b/molsym/salcs/projection_op.py
@@ -72,6 +72,11 @@ def ProjectionOp(symtext, fxn_set, project_Eckart=True):
 
     :type symtext: molsym.Symtext
     :type fxn_set: molsym.FunctionSet
+    :param project_Eckart: Only applies when fxn_set is CartesianCoordinates.
+        True projects out both translations and rotations (default), False
+        projects out neither, and 'translational' or 'rotational' projects
+        out only that subset of the Eckart conditions.
+    :type project_Eckart: bool or str
     :rtype: molsym.SALCs
     """
     numred = len(fxn_set)
@@ -95,7 +100,14 @@ def ProjectionOp(symtext, fxn_set, project_Eckart=True):
             # Project out Eckart conditions when constructing SALCs of Cartesian displacements
             if isinstance(fxn_set, CartesianCoordinates) and project_Eckart:
                 orthogonalize = True
-                eckart_cond = eckart_conditions(symtext)
+                if project_Eckart is True:
+                    eckart_cond = eckart_conditions(symtext)
+                elif project_Eckart == "translational":
+                    eckart_cond = eckart_conditions(symtext, translational=True, rotational=False)
+                elif project_Eckart == "rotational":
+                    eckart_cond = eckart_conditions(symtext, translational=False, rotational=True)
+                else:
+                    raise ValueError(f"Invalid value for project_Eckart: {project_Eckart!r}. Must be True, False, 'translational', or 'rotational'.")
                 for i in range(irrep.d):
                     for j in range(irrep.d):
                         if not np.allclose(salc[i,j,:], np.zeros(salc[i,j,:].shape), atol=salcs.tol):

--- a/test/test_projection_op.py
+++ b/test/test_projection_op.py
@@ -58,6 +58,78 @@ def test_internal_coordinate_SALCs(i):
     assert [salcs.salcs[j].irrep.symbol for j in range(len(ic_fxn_set))] == ic_irrep_labels_test_set[i]
 
 # Cartesian geometry SALCs with and without Eckart
+eckart_fns = ["water", "ammonia", "methane"]
+
+@pytest.mark.parametrize("fn", eckart_fns)
+def test_eckart_conditions_shapes_and_orthonormality(fn):
+    mol = molsym.Molecule.from_file(TEST_DIR / "xyz" / f"{fn}.xyz")
+    symtext = molsym.Symtext.from_molecule(mol)
+    n = 3 * mol.natoms
+
+    both = molsym.salcs.projection_op.eckart_conditions(symtext)
+    trans_only = molsym.salcs.projection_op.eckart_conditions(symtext, translational=True, rotational=False)
+    rot_only = molsym.salcs.projection_op.eckart_conditions(symtext, translational=False, rotational=True)
+
+    assert both.shape == (6, n)
+    assert trans_only.shape == (3, n)
+    assert rot_only.shape == (3, n)
+    np.testing.assert_allclose(both @ both.T, np.eye(6), atol=1e-8)
+
+def test_eckart_conditions_requires_translational_or_rotational():
+    mol = molsym.Molecule.from_file(TEST_DIR / "xyz" / "water.xyz")
+    symtext = molsym.Symtext.from_molecule(mol)
+    with pytest.raises(Exception):
+        molsym.salcs.projection_op.eckart_conditions(symtext, translational=False, rotational=False)
+
+@pytest.mark.parametrize("fn", eckart_fns)
+@pytest.mark.parametrize("project_Eckart,dof_removed", [
+    (True, 6),
+    (False, 0),
+    ("translational", 3),
+    ("rotational", 3),
+])
+def test_project_Eckart_salc_count(fn, project_Eckart, dof_removed):
+    # project_Eckart=True removes both translations and rotations (3N-6 vibrational
+    # SALCs remain); False removes neither (3N); 'translational'/'rotational' each
+    # remove only that 3-dimensional subspace (3N-3 remain).
+    mol = molsym.Molecule.from_file(TEST_DIR / "xyz" / f"{fn}.xyz")
+    symtext = molsym.Symtext.from_molecule(mol)
+    cart_coords = molsym.salcs.CartesianCoordinates(symtext)
+    salcs = molsym.salcs.projection_op.ProjectionOp(symtext, cart_coords, project_Eckart=project_Eckart)
+    assert len(salcs) == 3 * mol.natoms - dof_removed
+
+@pytest.mark.parametrize("fn", eckart_fns)
+def test_project_Eckart_translational_removes_translations(fn):
+    mol = molsym.Molecule.from_file(TEST_DIR / "xyz" / f"{fn}.xyz")
+    symtext = molsym.Symtext.from_molecule(mol)
+    cart_coords = molsym.salcs.CartesianCoordinates(symtext)
+
+    t = molsym.salcs.projection_op.eckart_conditions(symtext, translational=True, rotational=False)
+
+    salcs = molsym.salcs.projection_op.ProjectionOp(symtext, cart_coords, project_Eckart="translational")
+
+    for s in salcs.salcs:
+        np.testing.assert_allclose(t @ s.coeffs, np.zeros(3), atol=1e-8)
+
+@pytest.mark.parametrize("fn", eckart_fns)
+def test_project_Eckart_rotational_removes_rotations(fn):
+    mol = molsym.Molecule.from_file(TEST_DIR / "xyz" / f"{fn}.xyz")
+    symtext = molsym.Symtext.from_molecule(mol)
+    cart_coords = molsym.salcs.CartesianCoordinates(symtext)
+
+    r = molsym.salcs.projection_op.eckart_conditions(symtext, translational=False, rotational=True)
+
+    salcs = molsym.salcs.projection_op.ProjectionOp(symtext, cart_coords, project_Eckart="rotational")
+
+    for s in salcs.salcs:
+        np.testing.assert_allclose(r @ s.coeffs, np.zeros(3), atol=1e-8)
+
+def test_project_Eckart_invalid_value_raises():
+    mol = molsym.Molecule.from_file(TEST_DIR / "xyz" / "water.xyz")
+    symtext = molsym.Symtext.from_molecule(mol)
+    cart_coords = molsym.salcs.CartesianCoordinates(symtext)
+    with pytest.raises(ValueError):
+        molsym.salcs.projection_op.ProjectionOp(symtext, cart_coords, project_Eckart="dragons?")
 
 
 # Spherical harmonics SALCs


### PR DESCRIPTION
ProjectionOp's project_Eckart argument now accepts 'translational' or 'rotational' in addition to True/False, routing through to the existing translational/rotational options on eckart_conditions() so callers can project out just one subspace instead of always both.

Add tests covering eckart_conditions() shapes/orthonormality/exception, and the SALC counts and orthogonality guarantees for each project_Eckart mode.

This will assist with #56 and #48 