### PR TITLE
Derive package version from git tags instead of a hand-maintained string

### DIFF
--- a/.github/workflows/build-dist.yaml
+++ b/.github/workflows/build-dist.yaml
@@ -22,7 +22,12 @@ jobs:
     if: github.repository == 'NASymmetry/MolSym' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      # Version is derived from git tags via setuptools_scm, which needs full
+      # history and tags to find them (actions/checkout defaults to a shallow,
+      # tag-less fetch).
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,8 +20,13 @@ jobs:
       PYVER: ${{ matrix.cfg.python-version }}
       CONDA_ENV: ${{ matrix.cfg.conda-env }}
     steps:
+    # Version is derived from git tags via setuptools_scm, which needs full
+    # history and tags to find them (actions/checkout defaults to a shallow,
+    # tag-less fetch).
     - uses: actions/checkout@v2
-    
+      with:
+        fetch-depth: 0
+
     - name: Create Environment
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "MolSym"
-version = "0.2.1"
+dynamic = ["version"]
 description = "A program for molecular symmetry detection and SALC construction"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -34,3 +34,8 @@ Documentation = "https://molsym.readthedocs.io"
 
 [tool.setuptools.packages.find]
 include = ["molsym*"]
+
+[tool.setuptools_scm]
+# Derives the package version from the current git tag (e.g. tag "v1.0.1"
+# becomes version "1.0.1") instead of a hand-maintained version string, so it
+# can never drift from the tag a release was actually cut from.


### PR DESCRIPTION
pyproject.toml's version field had never been bumped since it was added, across both the v1.0.0 and v1.0.1 releases, so build-dist.yaml (which builds straight from pyproject.toml, not the release tag) was almost certainly publishing 0.2.1 to PyPI under both of those releases -- the same stale version that fed the in-review conda-forge recipe.

Switch to setuptools_scm so the version is always derived from the current git tag (verified against a checkout of v1.0.1: resolves cleanly to 1.0.1). Also add fetch-depth: 0 to the checkout steps in build-dist.yaml and workflow.yml, since GitHub's default shallow clone has no tag history and setuptools_scm would otherwise silently fall back to a meaningless version instead of erroring.