### PR TITLE
Remove Python 3.9 support, add Python 3.14 support.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,6 +16,8 @@ jobs:
             python-version: "3.12"
           - conda-env: base
             python-version: "3.13"
+          - conda-env: base
+            python-version: "3.14"
     env:
       PYVER: ${{ matrix.cfg.python-version }}
       CONDA_ENV: ${{ matrix.cfg.conda-env }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,10 +4,9 @@ jobs:
   run:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         cfg:
-          - conda-env: base
-            python-version: 3.9
           - conda-env: base
             python-version: "3.10"
           - conda-env: base

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ MolSym is also available on conda-forge and can be installed with `conda`:
 
   `conda install -c conda-forge molsym`
 
-MolSym is tested with Python 3.9–3.13, but should work for more recent versions and some older versions as well. Some features rely on the optional `QCElemental` dependency, which can be pulled in with:
+MolSym is tested with Python 3.10–3.14. Some features rely on the optional `QCElemental` dependency, which can be pulled in with:
 
   `pip install "molsym[qcel]"`
 

--- a/base.yaml
+++ b/base.yaml
@@ -8,7 +8,7 @@ dependencies:
   - numpy>=2.0.0
   - python
   - pip
-  - qcelemental>=0.28.0
+  - qcelemental>=0.50.0
   #- psi4
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - numpy>=2.0.0
-  - qcelemental >= 0.28.0
+  - qcelemental >= 0.50.0
   - sphinx >= 7.3.7
   - sphinx_rtd_theme >= 2.0.0
   - setuptools_scm >= 8

--- a/molsym/molecule.py
+++ b/molsym/molecule.py
@@ -100,7 +100,7 @@ class Molecule():
         with open(fn, "r") as lfn:
             strang = lfn.read()
 
-        schema = qcel.models.Molecule.from_data(strang).dict()
+        schema = qcel.models.v2.Molecule.from_data(strang).model_dump()
         if keep_angstrom:
             schema["geometry"] *= qcel.constants.bohr2angstroms
         return cls.from_schema(schema)
@@ -131,8 +131,8 @@ class Molecule():
         # Ang->Bohr from Molecule.from_schema
         if already_angstrom:
             self.coords /= qcel.constants.bohr2angstroms
-        qcmol = qcel.models.Molecule(
-            **{"symbols": self.atoms, 
+        qcmol = qcel.models.v2.Molecule(
+            **{"symbols": self.atoms,
             "geometry": self.coords})
         return qcmol.to_string("xyz")
 

--- a/molsym/symtext/symtext.py
+++ b/molsym/symtext/symtext.py
@@ -89,7 +89,7 @@ class Symtext():
         import qcelemental as qcel
         with open(fn, "r") as lfn:
             strang = lfn.read()
-        schema = qcel.models.Molecule.from_data(strang).dict()
+        schema = qcel.models.v2.Molecule.from_data(strang).model_dump()
         mol = Molecule.from_schema(schema)
         return cls.from_molecule(mol)
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "MolSym"
 dynamic = ["version"]
 description = "A program for molecular symmetry detection and SALC construction"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [
     { name = "Stephen Goodlett", email = "stephen.goodlett@org.chemie.uni-giessen.de" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 authors = [
-    { name = "Stephen Goodlett", email = "smg13363@uga.edu" },
-    { name = "Nate Kitzmiller", email = "nathaniel.kitzmiller@uga.edu" },
+    { name = "Stephen Goodlett", email = "stephen.goodlett@org.chemie.uni-giessen.de" },
+    { name = "Nate Kitzmiller", email = "nate.kitzmiller@indwes.edu" },
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -20,12 +20,9 @@ dependencies = [
     "numpy >= 1.23.4",
 ]
 
-# qcelemental is optional so the core molsym install/API path stays NumPy-only
-# (carried forward from #65). Install with `pip install MolSym[qcel]` to enable
-# the qcelemental-backed features.
 [project.optional-dependencies]
 qcel = [
-    "qcelemental >= 0.25.1",
+    "qcelemental >= 0.50.0",
 ]
 
 [project.urls]
@@ -36,6 +33,3 @@ Documentation = "https://molsym.readthedocs.io"
 include = ["molsym*"]
 
 [tool.setuptools_scm]
-# Derives the package version from the current git tag (e.g. tag "v1.0.1"
-# becomes version "1.0.1") instead of a hand-maintained version string, so it
-# can never drift from the tag a release was actually cut from.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,5 @@ pytest==7.2.2
 pytest-cov==4.0.0
 tomli==2.0.1
 numpy >= 1.23.4
-# qcelemental is optional; install it (or `molsym[qcel]`) for the file/schema/Psi4 loaders.
-qcelemental >= 0.25.1
+qcelemental >= 0.50.0
 


### PR DESCRIPTION
This PR updates the project's Python version requirements by dropping support for Python 3.9, which as has reached EOL, and set the minimum to Python 3.10

Changes:
- Updated `pyproject.toml` to require Python >=3.10 (was 3.9)
- Updated CI workflow to test against Python 3.10-3.14 (removed 3.9 from test matrix)
- Updated README.md to reflect tested versions as Python 3.10-3.14
- Pinned the floor QCElemental version to >=0.50.0 in various locations
- (slightly unrelated) updated the author's email addresses